### PR TITLE
The message 'Invalid UTF-8' is not an error.

### DIFF
--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -101,7 +101,7 @@ utf8_safe(V) ->
         V
     catch exit:{ucs, _} ->
             Enc = base64:encode(V),
-            <<"Invalid UTF-8, base64 is: ", Enc/binary>>
+            <<"Not UTF-8, base64 is: ", Enc/binary>>
     end.
 
 parameter(P) -> pset(value, rabbit_misc:term_to_json(pget(value, P)), P).


### PR DESCRIPTION
The statement appears to be an error message, but it isn't. It actually
means that the supplied binary is 'Not UTF-8' and thus needs to be encoded.