### PR TITLE
Support the new Time API in Erlang 18.0

### DIFF
--- a/src/rabbit_mgmt_db.erl
+++ b/src/rabbit_mgmt_db.erl
@@ -488,9 +488,9 @@ fine_stats_id(ChPid, {Q, X}) -> {ChPid, Q, X};
 fine_stats_id(ChPid, QorX)   -> {ChPid, QorX}.
 
 floor(TS, #state{interval = Interval}) ->
-    rabbit_mgmt_util:floor(rabbit_mgmt_format:now_to_ms(TS), Interval).
+    rabbit_mgmt_util:floor(TS, Interval).
 ceil(TS, #state{interval = Interval}) ->
-    rabbit_mgmt_util:ceil (rabbit_mgmt_format:now_to_ms(TS), Interval).
+    rabbit_mgmt_util:ceil (TS, Interval).
 
 details_key(Key) -> list_to_atom(atom_to_list(Key) ++ "_details").
 
@@ -1187,7 +1187,9 @@ gc_batch(Rows, Policies, State = #state{aggregated_stats = ETS,
           end,
     Key1 = case Key of
                '$end_of_table' -> undefined;
-               _               -> Now = floor(os:timestamp(), State),
+               _               -> Now = floor(
+                                    time_compat:os_system_time(milli_seconds),
+                                    State),
                                   Stats = ets:lookup_element(ETS, Key, 2),
                                   gc(Key, Stats, Policies, Now, ETS),
                                   Key

--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -17,7 +17,7 @@
 -module(rabbit_mgmt_format).
 
 -export([format/2, print/2, remove/1, ip/1, ipb/1, amqp_table/1, tuple/1]).
--export([parameter/1, now_to_str/1, now_to_str_ms/1, now_to_ms/1, strip_pids/1]).
+-export([parameter/1, now_to_str/1, now_to_str_ms/1, strip_pids/1]).
 -export([node_from_pid/1, protocol/1, resource/1, queue/1, queue_state/1]).
 -export([exchange/1, user/1, internal_user/1, binding/1, url/2]).
 -export([pack_binding_props/2, tokenise/1]).
@@ -124,21 +124,19 @@ protocol_version({Major, Minor, 0})        -> protocol_version({Major, Minor});
 protocol_version({Major, Minor, Revision}) -> io_lib:format("~B-~B-~B",
                                                     [Major, Minor, Revision]).
 
-now_to_ms(unknown) ->
-    unknown;
-now_to_ms(Now) ->
-    timer:now_diff(Now, {0,0,0}) div 1000.
-
 now_to_str(unknown) ->
     unknown;
-now_to_str(Now) ->
-    {{Y, M, D}, {H, Min, S}} = calendar:now_to_local_time(Now),
+now_to_str(MilliSeconds) ->
+    BaseDate = calendar:datetime_to_gregorian_seconds({{1970, 1, 1},
+                                                       {0, 0, 0}}),
+    Seconds = BaseDate + (MilliSeconds div 1000),
+    {{Y, M, D}, {H, Min, S}} = calendar:gregorian_seconds_to_datetime(Seconds),
     print("~w-~2.2.0w-~2.2.0w ~w:~2.2.0w:~2.2.0w", [Y, M, D, H, Min, S]).
 
 now_to_str_ms(unknown) ->
     unknown;
-now_to_str_ms(Now = {_, _, Micro}) ->
-    print("~s:~3.3.0w", [now_to_str(Now), Micro div 1000]).
+now_to_str_ms(MilliSeconds) ->
+    print("~s:~3.3.0w", [now_to_str(MilliSeconds), MilliSeconds rem 1000]).
 
 resource(unknown) -> unknown;
 resource(Res)     -> resource(name, Res).

--- a/src/rabbit_mgmt_stats.erl
+++ b/src/rabbit_mgmt_stats.erl
@@ -45,7 +45,7 @@ record(TS, Diff, Stats = #stats{diffs = Diffs}) ->
 %%----------------------------------------------------------------------------
 
 format(no_range, #stats{diffs = Diffs, base = Base}, Interval) ->
-    Now = rabbit_mgmt_format:now_to_ms(os:timestamp()),
+    Now = time_compat:os_system_time(milli_seconds),
     RangePoint = ((Now div Interval) * Interval) - Interval,
     Count = sum_entire_tree(gb_trees:iterator(Diffs), Base),
     {[{rate, format_rate(

--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -600,7 +600,7 @@ range(Prefix, Round, ReqData) ->
         is_integer(Age0) andalso is_integer(Incr0) ->
             Age = Age0 * 1000,
             Incr = Incr0 * 1000,
-            Now = rabbit_mgmt_format:now_to_ms(os:timestamp()),
+            Now = time_compat:os_system_time(milli_seconds),
             Last = Round(Now, Incr),
             #range{first = (Last - Age),
                    last  = Last,

--- a/test/src/rabbit_mgmt_test_db.erl
+++ b/test/src/rabbit_mgmt_test_db.erl
@@ -208,9 +208,7 @@ event(Type, Stats, Timestamp) ->
                          {event, #event{type      = Type,
                                         props     = Stats,
                                         reference = none,
-                                        timestamp = sec_to_triple(Timestamp)}}).
-
-sec_to_triple(Sec) -> {Sec div 1000000, Sec rem 1000000, 0}.
+                                        timestamp = Timestamp * 1000}}).
 
 %%----------------------------------------------------------------------------
 %% Events out


### PR DESCRIPTION
It must be merged **at the same time as** rabbitmq/rabbitmq-server#254.

References rabbitmq/rabbitmq-server#233.