### PR TITLE
Enable resource handlers to store data into context.

### DIFF
--- a/include/rabbit_mgmt.hrl
+++ b/include/rabbit_mgmt.hrl
@@ -14,7 +14,9 @@
 %%   Copyright (c) 2010-2015 Pivotal Software, Inc.  All rights reserved.
 %%
 
--record(context, {user, password = none}).
+-record(context, {user,
+                  password = none,
+                  impl}). % storage for a context of the resource handler
 -record(range, {first, last, incr}).
 -record(stats, {diffs, base}).
 


### PR DESCRIPTION
To process a request the Webmachine invokes several callbacks. This becomes inefficient and vulnerable to race conditions if the callbacks need to access a storage (e.g. a database). It would be nice if the handlers could store a context and load the value only once.

Example use-case: a plug-in that implements HTTP API for accessing the Last Value Cache
https://github.com/gotthardp/rabbitmq-lvc-management.git