### PR TITLE
Make GET /api/queues/vhost/name/get accept/provide application/json

### DIFF
--- a/src/rabbit_mgmt_wm_queue_get.erl
+++ b/src/rabbit_mgmt_wm_queue_get.erl
@@ -17,7 +17,7 @@
 -module(rabbit_mgmt_wm_queue_get).
 
 -export([init/1, resource_exists/2, post_is_create/2, is_authorized/2,
-         allowed_methods/2, process_post/2]).
+  allowed_methods/2, process_post/2, content_types_provided/2]).
 
 -include("rabbit_mgmt.hrl").
 -include_lib("webmachine/include/webmachine.hrl").
@@ -29,6 +29,10 @@ init(_Config) -> {ok, #context{}}.
 
 allowed_methods(ReqData, Context) ->
     {['POST'], ReqData, Context}.
+
+content_types_provided(ReqData, Context) ->
+   {[{"application/json", to_json}], ReqData, Context}.
+
 
 resource_exists(ReqData, Context) ->
     {case rabbit_mgmt_wm_queue:queue(ReqData) of


### PR DESCRIPTION
We had to change the `rabbit_mgmt_test_http` since by default accepted only  [`"Authorization"`](  
https://github.com/rabbitmq/rabbitmq-management/blob/master/test/src/rabbit_mgmt_test_http.erl#L1313) as header. 

We modified [`http_upload_raw`](https://github.com/rabbitmq/rabbitmq-management/commit/bd80c1d80b4c660d42c091e5b7e9ede24d31956c#diff-0dfa2103057664e04418da6fce836d7bR1308) with the parameter `MoreHeaders` .



  