### PR TITLE
JSON content-type for not authorized responses (401)

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -290,7 +290,7 @@ halt_response(Code, Type, Reason, ReqData, Context) ->
                      {reason, rabbit_mgmt_format:tuple(Reason)}]},
     ReqData1 = wrq:append_to_response_body(mochijson2:encode(Json), ReqData),
     {{halt, Code}, set_resp_header(
-             "Content-Type", "application/json",ReqData1), Context}.
+             "Content-Type", "application/json", ReqData1), Context}.
 
 id(Key, ReqData) when Key =:= exchange;
                       Key =:= source;

--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -289,7 +289,8 @@ halt_response(Code, Type, Reason, ReqData, Context) ->
     Json = {struct, [{error, Type},
                      {reason, rabbit_mgmt_format:tuple(Reason)}]},
     ReqData1 = wrq:append_to_response_body(mochijson2:encode(Json), ReqData),
-    {{halt, Code}, ReqData1, Context}.
+    {{halt, Code}, set_resp_header(
+             "Content-Type", "application/json",ReqData1), Context}.
 
 id(Key, ReqData) when Key =:= exchange;
                       Key =:= source;

--- a/test/src/rabbit_mgmt_test_http.erl
+++ b/test/src/rabbit_mgmt_test_http.erl
@@ -1180,7 +1180,7 @@ policy_permissions_test() ->
     ok.
 
 issue67_test()->
-    {ok, {{_, 401, _}, Headers, _}} =req(get, "/queues",
+    {ok, {{_, 401, _}, Headers, _}} = req(get, "/queues",
                         [auth_header("user_no_access", "password_no_access")]),
     ?assertEqual("application/json",
       proplists:get_value("content-type",Headers)),

--- a/test/src/rabbit_mgmt_test_http.erl
+++ b/test/src/rabbit_mgmt_test_http.erl
@@ -1179,6 +1179,12 @@ policy_permissions_test() ->
     rabbit_runtime_parameters_test:unregister(),
     ok.
 
+content_type_json_error_401_test()->
+    {ok, {{_, 401, _}, Headers, _}} =req(get,"/queues",
+                        [auth_header("user_no_access", "password_no_access")]),
+    ?assertEqual("application/json",
+      proplists:get_value("content-type",Headers)),
+    ok.
 
 extensions_test() ->
     [[{javascript,<<"dispatcher.js">>}]] = http_get("/extensions", ?OK),

--- a/test/src/rabbit_mgmt_test_http.erl
+++ b/test/src/rabbit_mgmt_test_http.erl
@@ -1179,8 +1179,8 @@ policy_permissions_test() ->
     rabbit_runtime_parameters_test:unregister(),
     ok.
 
-content_type_json_error_401_test()->
-    {ok, {{_, 401, _}, Headers, _}} =req(get,"/queues",
+issue67_test()->
+    {ok, {{_, 401, _}, Headers, _}} =req(get, "/queues",
                         [auth_header("user_no_access", "password_no_access")]),
     ?assertEqual("application/json",
       proplists:get_value("content-type",Headers)),


### PR DESCRIPTION
Fix [issue 67](https://github.com/rabbitmq/rabbitmq-management/issues/67) .

[Added](https://github.com/rabbitmq/rabbitmq-management/compare/stable...rabbitmq-management-67#diff-0ed5ba98e291c08176f90fe84a773a9aR292) `application/json` response header.
[Unit-test](https://github.com/rabbitmq/rabbitmq-management/compare/stable...rabbitmq-management-67#diff-0dfa2103057664e04418da6fce836d7bR1182) for `content-type` in `401` situation.  
