### PR TITLE
Empty HTTP API responses replace by null

### DIFF
--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -24,6 +24,7 @@
 -export([to_amqp_table/1, listener/1, properties/1, basic_properties/1]).
 -export([record/2, to_basic_properties/1]).
 -export([addr/1, port/1]).
+-export([format_nulls/1]).
 
 -import(rabbit_misc, [pget/2, pset/3]).
 
@@ -325,3 +326,27 @@ strip_pids(Item = [T | _]) when is_tuple(T) ->
            ]);
 
 strip_pids(Items) -> [strip_pids(I) || I <- Items].
+
+%% Format for JSON replies. Transforms '' into null
+format_nulls(Items) when is_list(Items) ->
+    lists:foldr(fun (Pair, Acc) ->
+			[format_null_item(Pair) | Acc]
+		end, [], Items);
+format_nulls(Item) ->
+    format_null_item(Item).
+
+format_null_item({Key, ''}) ->
+    {Key, null};
+format_null_item({Key, Value}) when is_list(Value) ->
+    {Key, format_nulls(Value)};
+format_null_item({Key, {struct, Struct}}) ->
+    {Key, {struct, format_nulls(Struct)}};
+format_null_item({Key, {array, Struct}}) ->
+    {Key, {array, format_nulls(Struct)}};
+format_null_item({Key, Value}) ->
+    {Key, Value};
+format_null_item([{_K, _V} | _T] = L) ->
+    format_nulls(L);
+format_null_item(Value) ->
+    Value.
+    

--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -349,4 +349,3 @@ format_null_item([{_K, _V} | _T] = L) ->
     format_nulls(L);
 format_null_item(Value) ->
     Value.
-    

--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -178,7 +178,8 @@ reply(Facts, ReqData, Context) ->
 reply0(Facts, ReqData, Context) ->
     ReqData1 = set_resp_header("Cache-Control", "no-cache", ReqData),
     try
-        {mochijson2:encode(Facts), ReqData1, Context}
+        {mochijson2:encode(rabbit_mgmt_format:format_nulls(Facts)), ReqData1,
+	 Context}
     catch exit:{json_encode, E} ->
             Error = iolist_to_binary(
                       io_lib:format("JSON encode error: ~p", [E])),

--- a/test/src/rabbit_mgmt_test_http.erl
+++ b/test/src/rabbit_mgmt_test_http.erl
@@ -870,6 +870,20 @@ sorting_test() ->
     http_delete("/vhosts/vh1", ?NO_CONTENT),
     ok.
 
+format_output_test() ->
+    QArgs = [],
+    PermArgs = [{configure, <<".*">>}, {write, <<".*">>}, {read, <<".*">>}],
+    http_put("/vhosts/vh1", none, ?NO_CONTENT),
+    http_put("/permissions/vh1/guest", PermArgs, ?NO_CONTENT),
+    http_put("/queues/%2f/test0", QArgs, ?NO_CONTENT),
+    assert_list([[{name, <<"test0">>},
+		  {consumer_utilisation, null},
+		  {exclusive_consumer_tag, null},
+		  {recoverable_slaves, null}]], http_get("/queues", ?OK)),
+    http_delete("/queues/%2f/test0", ?NO_CONTENT),
+    http_delete("/vhosts/vh1", ?NO_CONTENT),
+    ok.
+
 columns_test() ->
     http_put("/queues/%2f/test", [{arguments, [{<<"foo">>, <<"bar">>}]}],
              ?NO_CONTENT),


### PR DESCRIPTION
Fixes #26, the encoding of the empty atom should return a null in JSON