### PR TITLE
Delay rabbit_mgmt_db initialization

### DIFF
--- a/src/rabbit_mgmt_sup_sup.erl
+++ b/src/rabbit_mgmt_sup_sup.erl
@@ -57,7 +57,8 @@ start_child() -> supervisor2:start_child( ?MODULE, sup()).
 %%----------------------------------------------------------------------------
 
 init([]) ->
-    {ok, {{one_for_one, 0, 1}, [sup()]}}.
+    timer:apply_after(0, ?MODULE, start_child, []),
+    {ok, {{one_for_one, 0, 1}, []}}.
 
 sup() ->
     {rabbit_mgmt_sup, {rabbit_mgmt_sup, start_link, []},


### PR DESCRIPTION
It could prevent rabbit start in case when erlang nodes were
accidentially connected beforehand (e.g. by net_adm:ping/1).

Closes #81