### PR TITLE
Fix backwards sort arrow icon.

### DIFF
--- a/priv/www/js/formatters.js
+++ b/priv/www/js/formatters.js
@@ -734,7 +734,7 @@ function fmt_sort(display, sort) {
     var prefix = '';
     if (current_sort == sort) {
         prefix = '<span class="arrow">' +
-            (current_sort_reverse ? '&#9650; ' : '&#9660; ') +
+            (current_sort_reverse ? '&#9660; ' : '&#9650; ') +
             '</span>';
     }
     return '<a class="sort" sort="' + sort + '">' + prefix + display + '</a>';


### PR DESCRIPTION
It's conventional in GUIs to use a triangle or arrow icon to indicate how data is currently sorted in a column – where the wide part of the triangle being at the top and the narrow part at the bottom indicates that larger rows are above (decreasing sort), and vice versa.  In other words, the direction in which the icon width increases reflects the direction in which the values in the column increase.

The current icon is contrary to most UIs out there, which can be misleading – and it just feels plain wrong:

<img width="1167" alt="screen shot 2015-11-26 at 3 43 57 pm" src="https://cloud.githubusercontent.com/assets/1377702/11431884/70b2dae4-9456-11e5-9f14-9a4ccaaa35f8.png">

This PR swaps the two icons.