### PR TITLE
Help popup toggle on icon (?) click.

### DIFF
--- a/priv/www/css/main.css
+++ b/priv/www/css/main.css
@@ -42,6 +42,7 @@ div.box, div.section, div.section-hidden { overflow: auto; width: 100%; }
 
 .shortinput { width: 50px; text-align: right; }
 
+.help:after { content: '(?)'; }
 .help, .popup-options-link { color: #888; cursor: pointer; }
 .help:hover, .popup-options-link:hover { color: #444; }
 

--- a/priv/www/js/main.js
+++ b/priv/www/js/main.js
@@ -456,6 +456,10 @@ function show_popup(type, text, mode) {
     }
 
     hide();
+    if ($(cssClass).length && type === 'help' &&
+        $(cssClass).text().indexOf(text.replace(/<[^>]*>/g, '')) != -1 ) {
+        return;
+    }
     $('h1').after(format('error-popup', {'type': type, 'text': text}));
     if (mode == 'fade') {
         $(cssClass).fadeIn(200);
@@ -655,7 +659,6 @@ function postprocess_partial() {
             }
             update();
         });
-    $('.help').html('(?)');
     // TODO remove this hack when we get rid of "updatable"
     if ($('#filter-warning-show').length > 0) {
         $('#filter-truncate').addClass('filter-warning');


### PR DESCRIPTION
It's just a tiny fix for a thing which was annoying. It makes help popup disappear when help (?) is clicked second time. No need to move mouse around to Close popup. It also makes use of pseudo-elements to set the help (?) content.
![output_koovdo](https://cloud.githubusercontent.com/assets/14107724/11977526/83c3313a-a97b-11e5-80a4-a8b531e58a8d.gif)
