### PR TITLE
Limit sample ranges sent to the client

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -756,9 +756,8 @@ range(Prefix, Round, ReqData) ->
     Age0 = int(Prefix ++ "_age", ReqData),
     Incr0 = int(Prefix ++ "_incr", ReqData),
     if
-        is_integer(Age0) andalso is_integer(Incr0)
-        andalso (Age0 > 0) andalso (Incr0 > 0)
-        andalso ((Age0 div Incr0) =< ?MAX_RANGE) ->
+        is_atom(Age0) orelse is_atom(Incr0) -> no_range;
+        (Age0 > 0) andalso (Incr0 > 0) andalso ((Age0 div Incr0) =< ?MAX_RANGE) ->
             Age = Age0 * 1000,
             Incr = Incr0 * 1000,
             Now = time_compat:os_system_time(milli_seconds),
@@ -766,8 +765,9 @@ range(Prefix, Round, ReqData) ->
             #range{first = (Last - Age),
                    last  = Last,
                    incr  = Incr};
-        true ->
-            no_range
+        true -> throw({error, invalid_range_parameters,
+                    io_lib:format("Invalid range parameters: age ~p, incr ~p",
+                                  [Age0, Incr0])})
     end.
 
 floor(TS, Interval) -> (TS div Interval) * Interval.

--- a/src/rabbit_mgmt_wm_channel.erl
+++ b/src/rabbit_mgmt_wm_channel.erl
@@ -42,7 +42,12 @@ to_json(ReqData, Context) ->
       ReqData, Context).
 
 is_authorized(ReqData, Context) ->
-    rabbit_mgmt_util:is_authorized_user(ReqData, Context, channel(ReqData)).
+    try
+        rabbit_mgmt_util:is_authorized_user(ReqData, Context, channel(ReqData))
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 %%--------------------------------------------------------------------
 

--- a/src/rabbit_mgmt_wm_channels.erl
+++ b/src/rabbit_mgmt_wm_channels.erl
@@ -33,8 +33,13 @@ content_types_provided(ReqData, Context) ->
    {[{"application/json", to_json}], ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    rabbit_mgmt_util:reply_list_or_paginate(augmented(ReqData, Context),
-        ReqData, Context).
+    try
+        rabbit_mgmt_util:reply_list_or_paginate(augmented(ReqData, Context),
+            ReqData, Context)
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized(ReqData, Context).

--- a/src/rabbit_mgmt_wm_channels_vhost.erl
+++ b/src/rabbit_mgmt_wm_channels_vhost.erl
@@ -38,7 +38,12 @@ resource_exists(ReqData, Context) ->
     {rabbit_vhost:exists(rabbit_mgmt_util:id(vhost, ReqData)), ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    rabbit_mgmt_util:reply_list(augmented(ReqData, Context), ReqData, Context).
+    try
+        rabbit_mgmt_util:reply_list(augmented(ReqData, Context), ReqData, Context)
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized_vhost(ReqData, Context).

--- a/src/rabbit_mgmt_wm_connection.erl
+++ b/src/rabbit_mgmt_wm_connection.erl
@@ -57,7 +57,12 @@ delete_resource(ReqData, Context) ->
     {true, ReqData, Context}.
 
 is_authorized(ReqData, Context) ->
-    rabbit_mgmt_util:is_authorized_user(ReqData, Context, conn(ReqData)).
+    try
+        rabbit_mgmt_util:is_authorized_user(ReqData, Context, conn(ReqData))
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 %%--------------------------------------------------------------------
 

--- a/src/rabbit_mgmt_wm_connection_channels.erl
+++ b/src/rabbit_mgmt_wm_connection_channels.erl
@@ -45,8 +45,13 @@ to_json(ReqData, Context) ->
       ReqData, Context).
 
 is_authorized(ReqData, Context) ->
-    rabbit_mgmt_util:is_authorized_user(
-      ReqData, Context, rabbit_mgmt_wm_connection:conn(ReqData)).
+    try
+        rabbit_mgmt_util:is_authorized_user(
+          ReqData, Context, rabbit_mgmt_wm_connection:conn(ReqData))
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 %%--------------------------------------------------------------------
 

--- a/src/rabbit_mgmt_wm_connections.erl
+++ b/src/rabbit_mgmt_wm_connections.erl
@@ -33,8 +33,13 @@ content_types_provided(ReqData, Context) ->
    {[{"application/json", to_json}], ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    rabbit_mgmt_util:reply_list_or_paginate(augmented(ReqData, Context),
-        ReqData, Context).
+    try
+        rabbit_mgmt_util:reply_list_or_paginate(augmented(ReqData, Context),
+            ReqData, Context)
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized(ReqData, Context).

--- a/src/rabbit_mgmt_wm_connections_vhost.erl
+++ b/src/rabbit_mgmt_wm_connections_vhost.erl
@@ -38,7 +38,12 @@ resource_exists(ReqData, Context) ->
     {rabbit_vhost:exists(rabbit_mgmt_util:id(vhost, ReqData)), ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    rabbit_mgmt_util:reply_list(augmented(ReqData, Context), ReqData, Context).
+    try
+        rabbit_mgmt_util:reply_list(augmented(ReqData, Context), ReqData, Context)
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized_vhost(ReqData, Context).

--- a/src/rabbit_mgmt_wm_exchange.erl
+++ b/src/rabbit_mgmt_wm_exchange.erl
@@ -44,9 +44,14 @@ resource_exists(ReqData, Context) ->
      end, ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    [X] = rabbit_mgmt_db:augment_exchanges(
-            [exchange(ReqData)], rabbit_mgmt_util:range(ReqData), full),
-    rabbit_mgmt_util:reply(X, ReqData, Context).
+    try
+        [X] = rabbit_mgmt_db:augment_exchanges(
+                [exchange(ReqData)], rabbit_mgmt_util:range(ReqData), full),
+        rabbit_mgmt_util:reply(X, ReqData, Context)
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 accept_content(ReqData, Context) ->
     rabbit_mgmt_util:http_to_amqp(

--- a/src/rabbit_mgmt_wm_exchanges.erl
+++ b/src/rabbit_mgmt_wm_exchanges.erl
@@ -37,8 +37,13 @@ resource_exists(ReqData, Context) ->
      end, ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    rabbit_mgmt_util:reply_list_or_paginate(augmented(ReqData, Context),
-        ReqData, Context).
+    try
+        rabbit_mgmt_util:reply_list_or_paginate(augmented(ReqData, Context),
+            ReqData, Context)
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized_vhost(ReqData, Context).

--- a/src/rabbit_mgmt_wm_nodes.erl
+++ b/src/rabbit_mgmt_wm_nodes.erl
@@ -31,7 +31,12 @@ content_types_provided(ReqData, Context) ->
    {[{"application/json", to_json}], ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    rabbit_mgmt_util:reply_list(all_nodes(ReqData), ReqData, Context).
+    try
+        rabbit_mgmt_util:reply_list(all_nodes(ReqData), ReqData, Context)
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized_monitor(ReqData, Context).

--- a/src/rabbit_mgmt_wm_overview.erl
+++ b/src/rabbit_mgmt_wm_overview.erl
@@ -43,23 +43,28 @@ to_json(ReqData, Context = #context{user = User = #user{tags = Tags}}) ->
                  {cluster_name,        rabbit_nodes:cluster_name()},
                  {erlang_version,      erlang_version()},
                  {erlang_full_version, erlang_full_version()}],
-    Range = rabbit_mgmt_util:range(ReqData),
-    Overview =
-        case rabbit_mgmt_util:is_monitor(Tags) of
-            true ->
-                Overview0 ++
-                    [{K, maybe_struct(V)} ||
-                        {K,V} <- rabbit_mgmt_db:get_overview(Range)] ++
-                    [{node,               node()},
-                     {statistics_db_node, stats_db_node()},
-                     {listeners,          listeners()},
-                     {contexts,           web_contexts(ReqData)}];
-            _ ->
-                Overview0 ++
-                    [{K, maybe_struct(V)} ||
-                        {K, V} <- rabbit_mgmt_db:get_overview(User, Range)]
-        end,
-    rabbit_mgmt_util:reply(Overview, ReqData, Context).
+    try
+        Range = rabbit_mgmt_util:range(ReqData),
+        Overview =
+            case rabbit_mgmt_util:is_monitor(Tags) of
+                true ->
+                    Overview0 ++
+                        [{K, maybe_struct(V)} ||
+                            {K,V} <- rabbit_mgmt_db:get_overview(Range)] ++
+                        [{node,               node()},
+                         {statistics_db_node, stats_db_node()},
+                         {listeners,          listeners()},
+                         {contexts,           web_contexts(ReqData)}];
+                _ ->
+                    Overview0 ++
+                        [{K, maybe_struct(V)} ||
+                            {K, V} <- rabbit_mgmt_db:get_overview(User, Range)]
+            end,
+        rabbit_mgmt_util:reply(Overview, ReqData, Context)
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized(ReqData, Context).

--- a/src/rabbit_mgmt_wm_queue.erl
+++ b/src/rabbit_mgmt_wm_queue.erl
@@ -44,9 +44,14 @@ resource_exists(ReqData, Context) ->
      end, ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    [Q] = rabbit_mgmt_db:augment_queues(
-            [queue(ReqData)], rabbit_mgmt_util:range_ceil(ReqData), full),
-    rabbit_mgmt_util:reply(rabbit_mgmt_format:strip_pids(Q), ReqData, Context).
+    try
+        [Q] = rabbit_mgmt_db:augment_queues(
+                [queue(ReqData)], rabbit_mgmt_util:range_ceil(ReqData), full),
+        rabbit_mgmt_util:reply(rabbit_mgmt_format:strip_pids(Q), ReqData, Context)
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 accept_content(ReqData, Context) ->
    rabbit_mgmt_util:http_to_amqp(

--- a/src/rabbit_mgmt_wm_queues.erl
+++ b/src/rabbit_mgmt_wm_queues.erl
@@ -38,9 +38,13 @@ resource_exists(ReqData, Context) ->
 
 
 to_json(ReqData, Context) ->
-    rabbit_mgmt_util:reply_list_or_paginate(
-      augmented(ReqData, Context), ReqData, Context).
-
+    try
+        rabbit_mgmt_util:reply_list_or_paginate(
+          augmented(ReqData, Context), ReqData, Context)
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized_vhost(ReqData, Context).

--- a/src/rabbit_mgmt_wm_vhost.erl
+++ b/src/rabbit_mgmt_wm_vhost.erl
@@ -43,10 +43,15 @@ resource_exists(ReqData, Context) ->
     {rabbit_vhost:exists(id(ReqData)), ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    rabbit_mgmt_util:reply(
-      hd(rabbit_mgmt_db:augment_vhosts(
-           [rabbit_vhost:info(id(ReqData))], rabbit_mgmt_util:range(ReqData))),
-      ReqData, Context).
+    try
+        rabbit_mgmt_util:reply(
+          hd(rabbit_mgmt_db:augment_vhosts(
+               [rabbit_vhost:info(id(ReqData))], rabbit_mgmt_util:range(ReqData))),
+          ReqData, Context)
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 accept_content(ReqData, Context) ->
     Name = id(ReqData),

--- a/src/rabbit_mgmt_wm_vhosts.erl
+++ b/src/rabbit_mgmt_wm_vhosts.erl
@@ -31,8 +31,13 @@ content_types_provided(ReqData, Context) ->
    {[{"application/json", to_json}], ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    rabbit_mgmt_util:reply_list_or_paginate(
-      augmented(ReqData, Context),ReqData, Context).
+    try
+        rabbit_mgmt_util:reply_list_or_paginate(
+          augmented(ReqData, Context),ReqData, Context)
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized(ReqData, Context).


### PR DESCRIPTION
Update: I did now. (I did not change the behavior that silently dropped ranges when the input is invalid. I can change that into a proper error if required.)

Fixes https://github.com/rabbitmq/rabbitmq-management/issues/97.