### PR TITLE
Use the new `log_files` property reported by the agent

### DIFF
--- a/priv/www/doc/stats.html
+++ b/priv/www/doc/stats.html
@@ -575,9 +575,11 @@
         </td>
       </tr>
       <tr>
-        <td><code>log_file</code></td>
+        <td><code>log_files</code></td>
         <td>
-          Location of main log file.
+          List of log files used by the node. If the node also sends
+          messages to stdout, "<code>&lt;stdout&gt;</code>" is also
+          reported in the list.
         </td>
       </tr>
       <tr>

--- a/priv/www/js/tmpl/paths.ejs
+++ b/priv/www/js/tmpl/paths.ejs
@@ -11,7 +11,7 @@
     <td>
 <%
    for (var i = 0; i < node.config_files.length; i++) {
-     var config = node.config_files[i];
+     var config = fmt_escape_html(node.config_files[i]);
 %>
       <code><%= config %></code>
 <% } %>
@@ -24,15 +24,20 @@
     </td>
   </tr>
   <tr>
-    <th>Log file</th>
+    <th>
+<% if (node.log_files.length == 1) { %>
+      Log file
+<% } else { %>
+      Log files
+<% } %>
+    </th>
     <td>
-      <code><%= node.log_file %></code>
-    </td>
-  </tr>
-  <tr>
-    <th>SASL log file</th>
-    <td>
-      <code><%= node.sasl_log_file %></code>
+<%
+   for (var i = 0; i < node.log_files.length; i++) {
+     var config = fmt_escape_html(node.log_files[i]);
+%>
+      <code><%= config %></code>
+<% } %>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
This key contains a list of files. If the node sends messages to stdout, the list contains "`<stdout>`", therefore it needs to be escaped in an HTML context.

While here, escape `config_files` as well.

References rabbitmq/rabbitmq-server#94.