### PR TITLE
Accept any content-type for exchange-publish

### DIFF
--- a/src/rabbit_mgmt_wm_exchange_publish.erl
+++ b/src/rabbit_mgmt_wm_exchange_publish.erl
@@ -42,7 +42,7 @@ resource_exists(ReqData, Context) ->
      end, ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
-   {[{<<"application/json">>, accept_content}], ReqData, Context}.
+   {[{'*', accept_content}], ReqData, Context}.
 
 accept_content(ReqData, Context) ->
     rabbit_mgmt_util:post_respond(do_it(ReqData, Context)).


### PR DESCRIPTION
This restores the original behavior of accepting any content-type
when publishing new messages on exchanges. The payload is however
always JSON.

Fix for #107 

In the future it would be good to tighten this and only accept application/json. I tried looking in the JS to see where "text/plain" is set for this particular form, with no luck. Even if we decide to tighten in the future, this PR should still be merged because it at least fixes something broken.