### PR TITLE
Store cluster name as binary from the HTTP API

### DIFF
--- a/src/rabbit_mgmt_wm_cluster_name.erl
+++ b/src/rabbit_mgmt_wm_cluster_name.erl
@@ -46,7 +46,8 @@ to_json(ReqData, Context) ->
 accept_content(ReqData, Context) ->
     rabbit_mgmt_util:with_decode(
       [name], ReqData, Context, fun([Name], _) ->
-                                        rabbit_nodes:set_cluster_name(Name),
+                                        rabbit_nodes:set_cluster_name(
+                                          list_to_binary(Name)),
                                         {true, ReqData, Context}
                                 end).
 

--- a/src/rabbit_mgmt_wm_cluster_name.erl
+++ b/src/rabbit_mgmt_wm_cluster_name.erl
@@ -47,7 +47,7 @@ accept_content(ReqData, Context) ->
     rabbit_mgmt_util:with_decode(
       [name], ReqData, Context, fun([Name], _) ->
                                         rabbit_nodes:set_cluster_name(
-                                          list_to_binary(Name)),
+                                          as_binary(Name)),
                                         {true, ReqData, Context}
                                 end).
 
@@ -56,3 +56,8 @@ is_authorized(ReqData, Context) ->
         'PUT' -> rabbit_mgmt_util:is_authorized_admin(ReqData, Context);
         _     -> rabbit_mgmt_util:is_authorized(ReqData, Context)
     end.
+
+as_binary(Val) when is_binary(Val) ->
+    Val;
+as_binary(Val) when is_list(Val) ->
+    list_to_binary(Val).

--- a/test/src/rabbit_mgmt_test_http.erl
+++ b/test/src/rabbit_mgmt_test_http.erl
@@ -40,7 +40,7 @@ cluster_name_test() ->
                                {tags,     <<"management">>}], [?CREATED, ?NO_CONTENT]),
     http_put("/cluster-name", [{name, "foo"}], "myuser", "myuser", ?NOT_AUTHORISED),
     http_put("/cluster-name", [{name, "foo"}], ?NO_CONTENT),
-    [{name, "foo"}] = http_get("/cluster-name", "myuser", "myuser", ?OK),
+    [{name, <<"foo">>}] = http_get("/cluster-name", "myuser", "myuser", ?OK),
     http_delete("/users/myuser", ?NO_CONTENT),
     ok.
 


### PR DESCRIPTION
Fixes #143.

The problem is not in the display, but while setting the cluster name. The HTTP API was storing a string, while rabbit_nodes expects a binary (described in the spec but not enforced). With this fix the HTTP API stores a binary the same way rabbitmqctl does.