### PR TITLE
better naming conventions wrt delete / purge

### DIFF
--- a/priv/www/js/tmpl/queue.ejs
+++ b/priv/www/js/tmpl/queue.ejs
@@ -295,14 +295,14 @@
       <input type="hidden" name="vhost" value="<%= fmt_string(queue.vhost) %>"/>
       <input type="hidden" name="name" value="<%= fmt_string(queue.name) %>"/>
       <input type="hidden" name="mode" value="delete"/>
-      <input type="submit" value="Delete" />
+      <input type="submit" value="Delete Queue" />
     </form>
 
     <form action="#/queues" method="delete" class="inline-form-right">
       <input type="hidden" name="vhost" value="<%= fmt_string(queue.vhost) %>"/>
       <input type="hidden" name="name" value="<%= fmt_string(queue.name) %>"/>
       <input type="hidden" name="mode" value="purge"/>
-      <input type="submit" value="Purge" />
+      <input type="submit" value="Purge Queue" />
     </form>
   </div>
 </div>


### PR DESCRIPTION
https://github.com/rabbitmq/rabbitmq-management/issues/142

This will prevent the accidental deletions of a queue. Frankly, the position of delete/purge should also change, but I'll open another issue for that soon. The current state has delete on the far left and purge on the far right, a bit far away to notice it on first glance if you're new to rabbitmq and you've been asked to purge the queue.