### PR TITLE
Calculate average operation times from accumulated time and count

### DIFF
--- a/include/rabbit_mgmt_metrics.hrl
+++ b/include/rabbit_mgmt_metrics.hrl
@@ -36,10 +36,10 @@
 
 -define(COARSE_NODE_STATS,
         [mem_used, fd_used, sockets_used, proc_used, disk_free,
-         io_read_count,  io_read_bytes,  io_read_avg_time,
-         io_write_count, io_write_bytes, io_write_avg_time,
-         io_sync_count,  io_sync_avg_time,
-         io_seek_count,  io_seek_avg_time,
+         io_read_count,  io_read_bytes,  io_read_time,
+         io_write_count, io_write_bytes, io_write_time,
+         io_sync_count,  io_sync_time,
+         io_seek_count,  io_seek_time,
          io_reopen_count, mnesia_ram_tx_count,  mnesia_disk_tx_count,
          msg_store_read_count, msg_store_write_count,
          queue_index_journal_write_count,
@@ -51,8 +51,8 @@
 %% report". But for these things we do want to report even at 0 with
 %% no history.
 -define(ALWAYS_REPORT_STATS,
-        [io_read_avg_time, io_write_avg_time,
-         io_sync_avg_time | ?QUEUE_MSG_COUNTS]).
+        [io_read_time, io_write_time,
+         io_sync_time | ?QUEUE_MSG_COUNTS]).
 
 -define(COARSE_CONN_STATS, [recv_oct, send_oct]).
 
@@ -166,14 +166,14 @@
                             disk_free,
                             io_read_count,
                             io_read_bytes,
-                            io_read_avg_time,
+                            io_read_time,
                             io_write_count,
                             io_write_bytes,
-                            io_write_avg_time,
+                            io_write_time,
                             io_sync_count,
-                            io_sync_avg_time,
+                            io_sync_time,
                             io_seek_count,
-                            io_seek_avg_time,
+                            io_seek_time,
                             io_reopen_count,
                             mnesia_ram_tx_count,
                             mnesia_disk_tx_count,

--- a/src/rabbit_mgmt_event_collector_utils.erl
+++ b/src/rabbit_mgmt_event_collector_utils.erl
@@ -437,17 +437,8 @@ record_sample0({Type, {_ID1, _ID2}}, {_, _, _, #state{rates_mode = basic}})
 record_sample0({Type, Id0}, {Key0, Diff, TS, #state{}}) ->
     {Key, Pos} = stat_type(Key0),
     Id = {Id0, TS},
-    rabbit_mgmt_stats:record(Id, Pos, ensure_integer(Diff), Key,
+    rabbit_mgmt_stats:record(Id, Pos, Diff, Key,
                              rabbit_mgmt_stats_tables:aggr_table(Type, Key)).
-
-%% io_read_avg_time, io_write_avg_time, io_sync_avg_time and io_seek_avg_time
-%% are floats, thus can't be updated with ets:update_counter/3.
-%% This function transforms them into integers keeping 2 digits of precision.
-%% rabbit_mgmt_stats must revert this operation when querying them.
-ensure_integer(Value) when is_integer(Value) ->
-    Value;
-ensure_integer(Value) when is_float(Value) ->
-    trunc(Value * 100).
 
 %%------------------------------------------------------------------------------
 %% @hidden
@@ -505,22 +496,22 @@ stat_type(io_read_count) ->
     {coarse_node_stats, #coarse_node_stats.io_read_count};
 stat_type(io_read_bytes) ->
     {coarse_node_stats, #coarse_node_stats.io_read_bytes};
-stat_type(io_read_avg_time) ->
-    {coarse_node_stats, #coarse_node_stats.io_read_avg_time};
+stat_type(io_read_time) ->
+    {coarse_node_stats, #coarse_node_stats.io_read_time};
 stat_type(io_write_count) ->
     {coarse_node_stats, #coarse_node_stats.io_write_count};
 stat_type(io_write_bytes) ->
     {coarse_node_stats, #coarse_node_stats.io_write_bytes};
-stat_type(io_write_avg_time) ->
-    {coarse_node_stats, #coarse_node_stats.io_write_avg_time};
+stat_type(io_write_time) ->
+    {coarse_node_stats, #coarse_node_stats.io_write_time};
 stat_type(io_sync_count) ->
     {coarse_node_stats, #coarse_node_stats.io_sync_count};
-stat_type(io_sync_avg_time) ->
-    {coarse_node_stats, #coarse_node_stats.io_sync_avg_time};
+stat_type(io_sync_time) ->
+    {coarse_node_stats, #coarse_node_stats.io_sync_time};
 stat_type(io_seek_count) ->
     {coarse_node_stats, #coarse_node_stats.io_seek_count};
-stat_type(io_seek_avg_time) ->
-    {coarse_node_stats, #coarse_node_stats.io_seek_avg_time};
+stat_type(io_seek_time) ->
+    {coarse_node_stats, #coarse_node_stats.io_seek_time};
 stat_type(io_reopen_count) ->
     {coarse_node_stats, #coarse_node_stats.io_reopen_count};
 stat_type(mnesia_ram_tx_count) ->


### PR DESCRIPTION
Part of https://github.com/rabbitmq/rabbitmq-server/issues/557
Depends on https://github.com/rabbitmq/rabbitmq-management-agent/pull/13

Average operation times were miscalculated by handling them like any other system metric. These two PR solve this by reporting the raw data and calculating averages during the queries. Samples are reported as instant rates, so they truly reflect the behaviour of the system during that point in time.