### PR TITLE
Display user-provided connection name, if any

### DIFF
--- a/priv/www/js/tmpl/connection.ejs
+++ b/priv/www/js/tmpl/connection.ejs
@@ -1,4 +1,4 @@
-<h1>Connection <b><%= fmt_string(connection.client_properties.connection_name) %></b> <b><%= fmt_string(connection.name) %></b><%= fmt_maybe_vhost(connection.vhost) %></h1>
+<h1>Connection <b><%= fmt_string(connection.name) %></b> <%= fmt_maybe_vhost(connection.vhost) %></h1>
 
 <div class="section">
 <h2>Overview</h2>
@@ -13,6 +13,14 @@
   <td><%= fmt_node(connection.node) %></td>
 </tr>
 <% } %>
+
+<% if (connection.client_properties.connection_name) { %>
+<tr>
+  <th>Client-provided name</th>
+  <td><%= fmt_string(connection.client_properties.connection_name) %></td>
+</tr>
+<% } %>
+
 <tr>
  <th>Username</th>
  <td><%= fmt_string(connection.user) %></td>

--- a/priv/www/js/tmpl/connection.ejs
+++ b/priv/www/js/tmpl/connection.ejs
@@ -1,4 +1,4 @@
-<h1>Connection <b><%= fmt_string(connection.name) %></b><%= fmt_maybe_vhost(connection.vhost) %></h1>
+<h1>Connection <b><%= fmt_string(connection.client_properties.connection_name) %></b> <b><%= fmt_string(connection.name) %></b><%= fmt_maybe_vhost(connection.vhost) %></h1>
 
 <div class="section">
 <h2>Overview</h2>

--- a/priv/www/js/tmpl/connection.ejs
+++ b/priv/www/js/tmpl/connection.ejs
@@ -1,4 +1,4 @@
-<h1>Connection <b><%= fmt_string(connection.name) %></b> <%= fmt_maybe_vhost(connection.vhost) %></h1>
+<h1>Connection <%= fmt_string(connection.name) %> <%= fmt_maybe_vhost(connection.vhost) %></h1>
 
 <div class="section">
 <h2>Overview</h2>

--- a/priv/www/js/tmpl/connections.ejs
+++ b/priv/www/js/tmpl/connections.ejs
@@ -16,7 +16,7 @@
 <% if (vhosts_interesting) { %>
     <th><%= fmt_sort('Virtual host', 'vhost') %></th>
 <% } %>
-    <th><%= fmt_sort('Name',           'name') %></th>
+    <th><%= fmt_sort('Name',           'client_properties.connection_name;name') %></th>
 <% if (nodes_interesting) { %>
     <th><%= fmt_sort('Node',           'node') %></th>
 <% } %>
@@ -73,7 +73,13 @@
 <% if (vhosts_interesting) { %>
     <td><%= fmt_string(connection.vhost) %></td>
 <% } %>
+<% if(connection.client_properties.connection_name) { %>
+    <td><%= link_conn(connection.name, connection.client_properties.connection_name) %>
+        <%= fmt_string(short_conn(connection.name)) %>
+    </td>
+<% } else { %>
     <td><%= link_conn(connection.name) %></td>
+<% } %>
 <% if (nodes_interesting) { %>
     <td><%= fmt_node(connection.node) %></td>
 <% } %>

--- a/priv/www/js/tmpl/connections.ejs
+++ b/priv/www/js/tmpl/connections.ejs
@@ -74,8 +74,8 @@
     <td><%= fmt_string(connection.vhost) %></td>
 <% } %>
 <% if(connection.client_properties.connection_name) { %>
-    <td><%= link_conn(connection.name, connection.client_properties.connection_name) %>
-        <%= fmt_string(short_conn(connection.name)) %>
+    <td><%= link_conn(connection.name) %>
+        <%= fmt_string(short_conn(connection.client_properties.connection_name)) %>
     </td>
 <% } else { %>
     <td><%= link_conn(connection.name) %></td>

--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -388,6 +388,8 @@ get_dotted_value0([Key], Item) ->
 get_dotted_value0([Key | Keys], Item) ->
     get_dotted_value0(Keys, pget_bin(list_to_binary(Key), Item, [])).
 
+pget_bin(Key, {struct, List}, Default) ->
+    pget_bin(Key, List, Default);
 pget_bin(Key, List, Default) ->
     case lists:partition(fun ({K, _V}) -> a2b(K) =:= Key end, List) of
         {[{_K, V}], _} -> V;


### PR DESCRIPTION
If client provided client property `connection_name`, it will be displayed in management GUI.

Part of rabbitmq/rabbitmq-server#104.