### PR TITLE
Delete all relevant stats when channels/queues are closed/deleted

### DIFF
--- a/src/rabbit_mgmt_channel_stats_collector.erl
+++ b/src/rabbit_mgmt_channel_stats_collector.erl
@@ -35,7 +35,7 @@
 
 -define(DROP_LENGTH, 500).
 
-prioritise_cast({event, #event{props = Props}}, Len, _State)
+prioritise_cast({event, #event{type = channel_stats, props = Props}}, Len, _State)
   when Len > ?DROP_LENGTH ->
     case pget(idle_since, Props) of
         unknown -> drop;

--- a/src/rabbit_mgmt_queue_stats_collector.erl
+++ b/src/rabbit_mgmt_queue_stats_collector.erl
@@ -35,7 +35,7 @@
 
 -define(DROP_LENGTH, 500).
 
-prioritise_cast({event, #event{props = Props}}, Len, _State)
+prioritise_cast({event, #event{type = queue_stats, props = Props}}, Len, _State)
   when Len > ?DROP_LENGTH ->
     case pget(idle_since, Props) of
         unknown -> drop;

--- a/src/rabbit_mgmt_stats.erl
+++ b/src/rabbit_mgmt_stats.erl
@@ -454,12 +454,8 @@ indexes(Table, Id) ->
     lists:sort(ets:lookup(rabbit_mgmt_stats_tables:index(Table), Id)).
 
 full_indexes(Table, Id) ->
-    case ets:lookup(rabbit_mgmt_stats_tables:index(Table), Id) of
-        [] ->
-            [];
-        Indexes ->
-            [{Id, base}, {Id, total} | Indexes]
-    end.
+    Indexes = ets:lookup(rabbit_mgmt_stats_tables:index(Table), Id),
+    [{Id, base}, {Id, total} | Indexes].
 
 %%----------------------------------------------------------------------------
 %% Match specs to select or delete from the ETS tables


### PR DESCRIPTION
* Process all queue and channel events on their own collectors
* Ensure base and total are always deleted

Closes #173 with https://github.com/rabbitmq/rabbitmq-management-agent/pull/14