### PR TITLE
Add VHost to authorization properties

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -127,7 +127,11 @@ is_authorized(ReqData, Context, Username, Password, ErrorMsg, Fun) ->
                                         [Username, Msg]),
                      not_authorised(Msg, ReqData, Context)
              end,
-    case rabbit_access_control:check_user_pass_login(Username, Password) of
+    AuthProps = [{password, Password}] ++ case vhost(ReqData) of
+        VHost when is_binary(VHost) -> [{vhost, VHost}];
+        _                           -> []
+    end,
+    case rabbit_access_control:check_user_login(Username, AuthProps) of
         {ok, User = #user{tags = Tags}} ->
             IP = peer(ReqData),
             case rabbit_access_control:check_user_loopback(Username, IP) of


### PR DESCRIPTION
In https://github.com/rabbitmq/rabbitmq-auth-backend-ldap/issues/13 there should be a vhost variable in tag queries.
Since tags are needed by management, authorisation should add vhost to auth properties.