### PR TITLE
Set priority of collectors to high

### DIFF
--- a/src/rabbit_mgmt_channel_stats_collector.erl
+++ b/src/rabbit_mgmt_channel_stats_collector.erl
@@ -33,7 +33,7 @@
 -import(rabbit_misc, [pget/3]).
 -import(rabbit_mgmt_db, [pget/2, id_name/1, id/2, lookup_element/2]).
 
--define(DROP_LENGTH, 500).
+-define(DROP_LENGTH, 250).
 
 prioritise_cast({event, #event{type = channel_stats, props = Props}}, Len, _State)
   when Len > ?DROP_LENGTH ->
@@ -70,6 +70,7 @@ start_link() ->
 init([]) ->
     {ok, Interval} = application:get_env(rabbit, collect_statistics_interval),
     {ok, RatesMode} = application:get_env(rabbitmq_management, rates_mode),
+    process_flag(priority, high),
     rabbit_log:info("Statistics channel stats collector started.~n"),
     {ok, reset_lookups(
            #state{interval               = Interval,

--- a/src/rabbit_mgmt_event_collector.erl
+++ b/src/rabbit_mgmt_event_collector.erl
@@ -71,6 +71,7 @@ init([Ref]) ->
     {ok, Interval} = application:get_env(rabbit, collect_statistics_interval),
     {ok, RatesMode} = application:get_env(rabbitmq_management, rates_mode),
     rabbit_node_monitor:subscribe(self()),
+    process_flag(priority, high),
     rabbit_log:info("Statistics event collector started.~n"),
     ?TABLES = [ets:new(Key, [public, set, named_table]) || Key <- ?TABLES],
     ?AGGR_TABLES = [rabbit_mgmt_stats:blank(Name) || Name <- ?AGGR_TABLES],

--- a/src/rabbit_mgmt_queue_stats_collector.erl
+++ b/src/rabbit_mgmt_queue_stats_collector.erl
@@ -33,7 +33,7 @@
 -import(rabbit_misc, [pget/3]).
 -import(rabbit_mgmt_db, [pget/2, id_name/1, id/2, lookup_element/2]).
 
--define(DROP_LENGTH, 500).
+-define(DROP_LENGTH, 250).
 
 prioritise_cast({event, #event{type = queue_stats, props = Props}}, Len, _State)
   when Len > ?DROP_LENGTH ->
@@ -70,6 +70,7 @@ start_link() ->
 init([]) ->
     {ok, Interval} = application:get_env(rabbit, collect_statistics_interval),
     {ok, RatesMode} = application:get_env(rabbitmq_management, rates_mode),
+    process_flag(priority, high),
     rabbit_log:info("Statistics queue stats collector started.~n"),
     {ok, reset_lookups(
            #state{interval               = Interval,


### PR DESCRIPTION
* The massive amount of reductions causes the process to be re-scheduled very often,
  thus causing a massive memory increase. Restore flag to high as in 3.6.0

Fixes #185.