### PR TITLE
Avoid to use IE in compatibility mode 

### DIFF
--- a/priv/www/index.html
+++ b/priv/www/index.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 <html>
   <head>
     <title>RabbitMQ Management</title>


### PR DESCRIPTION
fixes https://github.com/rabbitmq/rabbitmq-management/issues/123 
It avoids  to use the `IE compatibility mode` for intranet site.
 