### PR TITLE
Prevent `~n` from appearing in logs

### DIFF
--- a/src/rabbit_mgmt_app.erl
+++ b/src/rabbit_mgmt_app.erl
@@ -54,7 +54,7 @@ unregister_context() ->
     rabbit_web_dispatch:unregister_context(?CONTEXT).
 
 log_startup(Listener) ->
-    rabbit_log:info("Management plugin started. Port: ~w~n", [port(Listener)]).
+    rabbit_log:info("Management plugin started. Port: ~w", [port(Listener)]).
 
 port(Listener) ->
     proplists:get_value(port, Listener).

--- a/src/rabbit_mgmt_channel_stats_collector.erl
+++ b/src/rabbit_mgmt_channel_stats_collector.erl
@@ -71,7 +71,7 @@ init([]) ->
     {ok, Interval} = application:get_env(rabbit, collect_statistics_interval),
     {ok, RatesMode} = application:get_env(rabbitmq_management, rates_mode),
     process_flag(priority, high),
-    rabbit_log:info("Statistics channel stats collector started.~n"),
+    rabbit_log:info("Statistics channel stats collector started."),
     {ok, reset_lookups(
            #state{interval               = Interval,
                   rates_mode             = RatesMode}), hibernate,

--- a/src/rabbit_mgmt_db.erl
+++ b/src/rabbit_mgmt_db.erl
@@ -178,7 +178,7 @@ init([]) ->
     %% that the management plugin work.
     process_flag(priority, high),
     {ok, Interval} = application:get_env(rabbit, collect_statistics_interval),
-    rabbit_log:info("Statistics database started.~n"),
+    rabbit_log:info("Statistics database started."),
     {ok, #state{interval = Interval}, hibernate,
      {backoff, ?HIBERNATE_AFTER_MIN, ?HIBERNATE_AFTER_MIN, ?DESIRED_HIBERNATE}}.
 

--- a/src/rabbit_mgmt_event_collector.erl
+++ b/src/rabbit_mgmt_event_collector.erl
@@ -71,7 +71,7 @@ init([Ref]) ->
     {ok, Interval} = application:get_env(rabbit, collect_statistics_interval),
     {ok, RatesMode} = application:get_env(rabbitmq_management, rates_mode),
     rabbit_node_monitor:subscribe(self()),
-    rabbit_log:info("Statistics event collector started.~n"),
+    rabbit_log:info("Statistics event collector started."),
     ?TABLES = [ets:new(Key, [public, set, named_table]) || Key <- ?TABLES],
     %% Index for the deleting of fine stats, reduces the number of reductions
     %% to 1/8 under heavy load.

--- a/src/rabbit_mgmt_load_definitions.erl
+++ b/src/rabbit_mgmt_load_definitions.erl
@@ -37,7 +37,7 @@ maybe_load_definitions() ->
         none -> ok;
         _    -> case file:read_file(File) of
                     {ok, Body} -> rabbit_log:info(
-                                    "Applying definitions from: ~s~n", [File]),
+                                    "Applying definitions from: ~s", [File]),
                                   load_definitions(Body);
                     {error, E} -> {error, {could_not_read_defs, {File, E}}}
                 end

--- a/src/rabbit_mgmt_queue_stats_collector.erl
+++ b/src/rabbit_mgmt_queue_stats_collector.erl
@@ -71,7 +71,7 @@ init([]) ->
     {ok, Interval} = application:get_env(rabbit, collect_statistics_interval),
     {ok, RatesMode} = application:get_env(rabbitmq_management, rates_mode),
     process_flag(priority, high),
-    rabbit_log:info("Statistics queue stats collector started.~n"),
+    rabbit_log:info("Statistics queue stats collector started."),
     {ok, reset_lookups(
            #state{interval               = Interval,
                   rates_mode             = RatesMode}), hibernate,

--- a/src/rabbit_mgmt_stats_gc.erl
+++ b/src/rabbit_mgmt_stats_gc.erl
@@ -63,7 +63,7 @@ start_link(Table) ->
 
 init([Table]) ->
     {ok, Interval} = application:get_env(rabbit, collect_statistics_interval),
-    rabbit_log:info("Statistics garbage collector started for table ~p.~n", [Table]),
+    rabbit_log:info("Statistics garbage collector started for table ~p.", [Table]),
     {ok, set_gc_timer(#state{interval = Interval,
                              gc_table = Table,
                              gc_index = rabbit_mgmt_stats_tables:key_index(Table)}),

--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -121,7 +121,7 @@ is_authorized(ReqData, Context, ErrorMsg, Fun) ->
 
 is_authorized(ReqData, Context, Username, Password, ErrorMsg, Fun) ->
     ErrFun = fun (Msg) ->
-                     rabbit_log:warning("HTTP access denied: user '~s' - ~s~n",
+                     rabbit_log:warning("HTTP access denied: user '~s' - ~s",
                                         [Username, Msg]),
                      not_authorised(Msg, ReqData, Context)
              end,
@@ -149,7 +149,7 @@ is_authorized(ReqData, Context, Username, Password, ErrorMsg, Fun) ->
                     ErrFun(<<"User can only log in via localhost">>)
             end;
         {refused, _Username, Msg, Args} ->
-            rabbit_log:warning("HTTP access denied: ~s~n",
+            rabbit_log:warning("HTTP access denied: ~s",
                                [rabbit_misc:format(Msg, Args)]),
             not_authorised(<<"Login failed">>, ReqData, Context)
     end.
@@ -433,7 +433,7 @@ not_found(Reason, ReqData, Context) ->
     halt_response(404, not_found, Reason, ReqData, Context).
 
 internal_server_error(Error, Reason, ReqData, Context) ->
-    rabbit_log:error("~s~n~s~n", [Error, Reason]),
+    rabbit_log:error("~s~n~s", [Error, Reason]),
     halt_response(500, Error, Reason, ReqData, Context).
 
 invalid_pagination(Type,Reason, ReqData, Context) ->


### PR DESCRIPTION
`lager` is ignoring all formatting sequences, if there is no format
arguments - as an optimisation. As a result logs can sometimes contain
ugly '~n'-s.