### PR TITLE
Sweep records for abnormally terminated channel and connection

### DIFF
--- a/include/rabbit_mgmt_metrics.hrl
+++ b/include/rabbit_mgmt_metrics.hrl
@@ -140,6 +140,9 @@
          aggr_connection_stats_coarse_conn_stats_key_index
         ]).
 
+-define(PROC_STATS_TABLES,
+        [channel_stats, connection_stats]).
+
 %% Records are only used to retrieve the field position and to facilitate
 %% keeping track of the data
 -record(deliver_get, {deliver,

--- a/src/rabbit_mgmt_event_collector.erl
+++ b/src/rabbit_mgmt_event_collector.erl
@@ -73,6 +73,9 @@ init([Ref]) ->
     rabbit_node_monitor:subscribe(self()),
     rabbit_log:info("Statistics event collector started.~n"),
     ?TABLES = [ets:new(Key, [public, set, named_table]) || Key <- ?TABLES],
+    %% Index for deleting stats of killed processes.
+    [ets:new(rabbit_mgmt_stats_tables:key_index(Table),
+             [ordered_set, public, named_table]) || Table <- ?PROC_STATS_TABLES],
     %% Index for the deleting of fine stats, reduces the number of reductions
     %% to 1/8 under heavy load.
     ets:new(old_stats_fine_index, [bag, public, named_table]),

--- a/src/rabbit_mgmt_event_collector_utils.erl
+++ b/src/rabbit_mgmt_event_collector_utils.erl
@@ -185,9 +185,12 @@ ceil(TS, #state{interval = Interval}) ->
 
 handle_created(TName, Stats, Funs) ->
     Formatted = rabbit_mgmt_format:format(Stats, Funs),
-    ets:insert(TName, {{id(TName, Stats), create},
-                                              Formatted,
-                                              pget(name, Stats)}).
+    Id = id(TName, Stats),
+    ets:insert(TName, {{Id, create}, Formatted, pget(name, Stats)}),
+    case lists:member(TName, ?PROC_STATS_TABLES) of
+        true  -> ets:insert(rabbit_mgmt_stats_tables:key_index(TName), {Id});
+        false -> true
+    end.
 
 handle_deleted(TName, #event{props = Props}) ->
     Id = id(TName, Props),

--- a/src/rabbit_mgmt_event_collector_utils.erl
+++ b/src/rabbit_mgmt_event_collector_utils.erl
@@ -199,7 +199,11 @@ handle_deleted(TName, #event{props = Props}) ->
                  ets:delete(TName, {Id, stats});
         false -> ok
     end,
-    ets:delete(old_stats, {coarse, {TName, Id}}).
+    ets:delete(old_stats, {coarse, {TName, Id}}),
+    case lists:member(TName, ?PROC_STATS_TABLES) of
+        true  -> ets:delete(rabbit_mgmt_stats_tables:key_index(TName), Id);
+        false -> true
+    end.
 
 handle_consumer(Fun, Props) ->
     P = rabbit_mgmt_format:format(Props, {[], false}),

--- a/src/rabbit_mgmt_stats_gc.erl
+++ b/src/rabbit_mgmt_stats_gc.erl
@@ -45,7 +45,7 @@
 
 -define(DROP_LENGTH, 1000).
 
--define(PROCESS_ALIVENESS_TIMEOUT, 5000).
+-define(PROCESS_ALIVENESS_TIMEOUT, 15000).
 
 %%----------------------------------------------------------------------------
 %% API
@@ -167,14 +167,12 @@ gc_aggr(Key, Table, Config, Now) ->
     rabbit_mgmt_stats:gc({Policy, Now}, Table, Key).
 
 maybe_gc_process(Pid, Table, LastStatsTS, Now, Timeout) ->
-    rabbit_log:error("Maybe GC process ~p~n", [{Table, LastStatsTS, Now, Timeout, Pid}]),
     case Now - LastStatsTS < Timeout of
         true  -> ok;
         false ->
             case process_status(Pid) of
                 %% Process doesn't exist on remote node
-                undefined -> rabbit_log:error("GC process ~p~n", [{Table, Pid}]),
-                             rabbit_event:notify(deleted_event(Table),
+                undefined -> rabbit_event:notify(deleted_event(Table),
                                                  [{pid, Pid}]);
                 %% Remote node is unreachable or process is alive
                 _        -> ok

--- a/src/rabbit_mgmt_stats_tables.erl
+++ b/src/rabbit_mgmt_stats_tables.erl
@@ -198,6 +198,10 @@ index(aggr_connection_stats_coarse_conn_stats) ->
 index(A) when is_integer(A) ->
     list_to_atom(integer_to_list(A) ++ "_index").
 
+key_index(connection_stats) ->
+    connection_stats_key_index;
+key_index(channel_stats) ->
+    channel_stats_key_index;
 key_index(aggr_queue_stats_deliver_get) ->
     aggr_queue_stats_deliver_get_key_index;
 key_index(aggr_queue_stats_fine_stats) ->

--- a/src/rabbit_mgmt_sup.erl
+++ b/src/rabbit_mgmt_sup.erl
@@ -37,9 +37,12 @@ init([]) ->
     GC = [{rabbit_mgmt_stats_gc:name(Table), {rabbit_mgmt_stats_gc, start_link, [Table]},
            permanent, ?MAX_WAIT, worker, [rabbit_mgmt_stats_gc]}
           || Table <- ?AGGR_TABLES],
+    ProcGC = [{rabbit_mgmt_stats_gc:name(Table), {rabbit_mgmt_stats_gc, start_link, [Table]},
+           permanent, ?MAX_WAIT, worker, [rabbit_mgmt_stats_gc]}
+          || Table <- ?PROC_STATS_TABLES],
     DB = {rabbit_mgmt_db, {rabbit_mgmt_db, start_link, []},
           permanent, ?MAX_WAIT, worker, [rabbit_mgmt_db]},
-    {ok, {{one_for_one, 10, 10}, [COLLECTOR, CCOLLECTOR, QCOLLECTOR, DB] ++ GC}}.
+    {ok, {{one_for_one, 10, 10}, [COLLECTOR, CCOLLECTOR, QCOLLECTOR, DB] ++ GC ++ ProcGC}}.
 
 start_link() ->
      mirrored_supervisor:start_link(

--- a/src/rabbitmq_management.app.src
+++ b/src/rabbitmq_management.app.src
@@ -13,6 +13,7 @@
           [{global,   [{605, 5}, {3660, 60}, {29400, 600}, {86400, 1800}]},
            {basic,    [{605, 5}, {3600, 60}]},
            {detailed, [{10, 5}]}]},
+         {process_stats_gc_timeout, 300000},
          {cors_allow_origins, []},
          {cors_max_age, 1800}
         ]},


### PR DESCRIPTION
Fixes #198 
Connection and channel stats will be periodically scanned and if last stats was long ago - process aliveness is checked.
If process is known to be dead (node is reachable, process with pid doesn't exist) - connection/channel delete event is sent.

Added `_key_index` tables for `channel_stats` and `connection_stats` tables.
Starting `_gc` process for `channel_stats` and `connection_stats` tables.
Added new env variable `process_stats_gc_timeout` to specify period since last stats event for connection/channel to check aliveness.

Process aliveness is checked with `rpc:pinfo`, which is calling remote node with `infinity` timeout. I could not managed to crash it, but internode communication still require attention.