### PR TITLE
Clean up old_stats_fine_index

### DIFF
--- a/src/rabbit_mgmt_event_collector_utils.erl
+++ b/src/rabbit_mgmt_event_collector_utils.erl
@@ -107,6 +107,7 @@ handle_event(#event{type = channel_stats, props = Stats, timestamp = Timestamp},
     AllStats = [old_fine_stats(ChPid, Type, Stats)
                 || Type <- ?FINE_STATS_TYPES],
     Objs = ets:lookup(old_stats_fine_index, ChPid),
+    ets:delete(old_stats_fine_index, ChPid),
     [ets:delete(old_stats, Key) || {_, Key} <- Objs],
     %% This ceil must correspond to the ceil in handle_event
     %% queue_deleted
@@ -121,6 +122,7 @@ handle_event(Event = #event{type = channel_closed,
     delete_samples(channel_stats,          Pid),
     handle_deleted(channel_stats, Event),
     Objs = ets:lookup(old_stats_fine_index, Pid),
+    ets:delete(old_stats_fine_index, Pid),
     [ets:delete(old_stats, Key) || {_, Key} <- Objs];
 
 handle_event(#event{type = consumer_created, props = Props}, _State) ->


### PR DESCRIPTION
Related to #216 
When using `rates_mode` other than `none`, opening and closing multiple channels in single connection can cause memory leak to `binaries`.
This was due to weird `ets` behaviour caused by growing `old_stats_fine_index` table.
Detected with stress-testing tool, mentioned in #216
