### PR TITLE
API endpoint to show per-table ETS memory consumption

### DIFF
--- a/src/rabbit_mgmt_dispatcher.erl
+++ b/src/rabbit_mgmt_dispatcher.erl
@@ -43,6 +43,10 @@ dispatcher() ->
      {["nodes", node],                                             rabbit_mgmt_wm_node, []},
      {["nodes", node, "memory"],                                   rabbit_mgmt_wm_node_memory, [absolute]},
      {["nodes", node, "memory", "relative"],                       rabbit_mgmt_wm_node_memory, [relative]},
+     {["nodes", node, "memory", "ets"],                            rabbit_mgmt_wm_node_memory_ets, [absolute]},
+     {["nodes", node, "memory", "ets", "relative"],                rabbit_mgmt_wm_node_memory_ets, [relative]},
+     {["nodes", node, "memory", "ets", filter],                    rabbit_mgmt_wm_node_memory_ets, [absolute]},
+     {["nodes", node, "memory", "ets", filter, "relative"],        rabbit_mgmt_wm_node_memory_ets, [relative]},
      {["extensions"],                                              rabbit_mgmt_wm_extensions, []},
      {["all-configuration"],                                       rabbit_mgmt_wm_definitions, []}, %% This was the old name, let's not break things gratuitously.
      {["definitions"],                                             rabbit_mgmt_wm_definitions, []},

--- a/src/rabbit_mgmt_wm_node_memory_ets.erl
+++ b/src/rabbit_mgmt_wm_node_memory_ets.erl
@@ -1,0 +1,102 @@
+%%   The contents of this file are subject to the Mozilla Public License
+%%   Version 1.1 (the "License"); you may not use this file except in
+%%   compliance with the License. You may obtain a copy of the License at
+%%   http://www.mozilla.org/MPL/
+%%
+%%   Software distributed under the License is distributed on an "AS IS"
+%%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%%   License for the specific language governing rights and limitations
+%%   under the License.
+%%
+%%   The Original Code is RabbitMQ Management Console.
+%%
+%%   The Initial Developer of the Original Code is GoPivotal, Inc.
+%%   Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(rabbit_mgmt_wm_node_memory_ets).
+
+-export([init/1, to_json/2, content_types_provided/2, is_authorized/2]).
+-export([finish_request/2, allowed_methods/2]).
+-export([encodings_provided/2]).
+-export([resource_exists/2]).
+
+-include("rabbit_mgmt.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+%%--------------------------------------------------------------------
+
+init([Mode]) -> {ok, {Mode, #context{}}}.
+
+finish_request(ReqData, {Mode, Context}) ->
+    {ok, rabbit_mgmt_cors:set_headers(ReqData, Context), {Mode, Context}}.
+
+allowed_methods(ReqData, Context) ->
+    {['HEAD', 'GET', 'OPTIONS'], ReqData, Context}.
+
+content_types_provided(ReqData, Context) ->
+   {[{"application/json", to_json}], ReqData, Context}.
+
+encodings_provided(ReqData, Context) ->
+    {[{"identity", fun(X) -> X end},
+     {"gzip", fun(X) -> zlib:gzip(X) end}], ReqData, Context}.
+
+resource_exists(ReqData, Context) ->
+    {node_exists(ReqData, get_node(ReqData)), ReqData, Context}.
+
+to_json(ReqData, {Mode, Context}) ->
+    rabbit_mgmt_util:reply(augment(Mode, ReqData), ReqData, {Mode, Context}).
+
+is_authorized(ReqData, {Mode, Context}) ->
+    {Res, RD, C} = rabbit_mgmt_util:is_authorized_monitor(ReqData, Context),
+    {Res, RD, {Mode, C}}.
+
+%%--------------------------------------------------------------------
+get_node(ReqData) ->
+    list_to_atom(binary_to_list(rabbit_mgmt_util:id(node, ReqData))).
+
+get_filter(ReqData) ->
+    case rabbit_mgmt_util:id(filter, ReqData) of
+        none                        -> all;
+        <<"management">>            -> rabbit_mgmt_event_collector;
+        Other when is_binary(Other) -> list_to_atom(binary_to_list(Other));
+        _                           -> all
+    end.
+
+node_exists(ReqData, Node) ->
+    case [N || N <- rabbit_mgmt_wm_nodes:all_nodes(ReqData),
+               proplists:get_value(name, N) == Node] of
+        [] -> false;
+        [_] -> true
+    end.
+
+augment(Mode, ReqData) ->
+    Node = get_node(ReqData),
+    Filter = get_filter(ReqData),
+    case node_exists(ReqData, Node) of
+        false ->
+            not_found;
+        true ->
+            case rpc:call(Node, rabbit_vm, ets_tables_memory,
+                          [Filter], infinity) of
+                {badrpc, _} -> [{ets_tables_memory, not_available}];
+                []          -> [{ets_tables_memory, no_tables}];
+                Result      -> [{ets_tables_memory, format(Mode, Result)}]
+            end
+    end.
+
+format(absolute, Result) ->
+    Total = lists:sum([V || {_K,V} <- Result]),
+    [{total, Total} | Result];
+format(relative, Result) ->
+    Total = lists:sum([V || {_K,V} <- Result]),
+    [{total, 100} | [{K, percentage(V, Total)} || {K, V} <- Result]].
+
+percentage(Part, Total) ->
+    case round((Part/Total) * 100) of
+        0 when Part =/= 0 ->
+            1;
+        Int ->
+            Int
+    end.

--- a/test/src/rabbit_mgmt_test_util.erl
+++ b/test/src/rabbit_mgmt_test_util.erl
@@ -16,7 +16,8 @@
 
 -module(rabbit_mgmt_test_util).
 
--export([assert_list/2, assert_item/2, test_item/2, assert_keys/2]).
+-export([assert_list/2, assert_item/2, test_item/2,
+         assert_keys/2, assert_no_keys/2]).
 
 assert_list(Exp, Act) ->
     case length(Exp) == length(Act) of
@@ -53,3 +54,12 @@ assert_keys(Exp, Act) ->
 test_key0(Exp, Act) ->
     [{did_not_find, ExpI, in, Act} || ExpI <- Exp,
                                       not proplists:is_defined(ExpI, Act)].
+assert_no_keys(NotExp, Act) ->
+    case test_no_key0(NotExp, Act) of
+        [] -> ok;
+        Or -> throw(Or)
+    end.
+
+test_no_key0(Exp, Act) ->
+    [{invalid_key, ExpI, in, Act} || ExpI <- Exp,
+                                      proplists:is_defined(ExpI, Act)].


### PR DESCRIPTION
Fixes #219 
Requires https://github.com/rabbitmq/rabbitmq-server/pull/827

Added a new API endpoint:
```
/api/nodes/node/memory/ets - all tables
/api/nodes/node/memory/ets/relative - all tables in percentage
/api/nodes/node/memory/ets/management - management statistics tables
/api/nodes/node/memory/ets/management/relative - management statistics tables in percentage
/api/nodes/node/memory/ets/proc_name - tables owned by process "proc_name"
/api/nodes/node/memory/ets/proc_name/relative - tables owned by process "proc_name" in percentage
```

Returns
```
{
  "ets_tables_memory" : {
    "total" : <sum>,
    "table_name1" : 200,
    "table_name2" : 200,
    ...
  }
}
```
Absolute values are reported in bytes.

If owner process doesn't exist or owns no ETS tables, `{"ets_tables_memory", "no_tables"}`
