### PR TITLE
Set bounded timeout for OTP workers

### DIFF
--- a/src/rabbit_mgmt_sup.erl
+++ b/src/rabbit_mgmt_sup.erl
@@ -27,21 +27,21 @@
 init([]) ->
     COLLECTOR = {rabbit_mgmt_event_collector,
                  {rabbit_mgmt_event_collector, start_link, []},
-                 permanent, ?MAX_WAIT, worker, [rabbit_mgmt_event_collector]},
+                 permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_event_collector]},
     CCOLLECTOR = {rabbit_mgmt_channel_stats_collector,
                   {rabbit_mgmt_channel_stats_collector, start_link, []},
-                  permanent, ?MAX_WAIT, worker, [rabbit_mgmt_channel_stats_collector]},
+                  permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_channel_stats_collector]},
     QCOLLECTOR = {rabbit_mgmt_queue_stats_collector,
                   {rabbit_mgmt_queue_stats_collector, start_link, []},
-                  permanent, ?MAX_WAIT, worker, [rabbit_mgmt_queue_stats_collector]},
+                  permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_queue_stats_collector]},
     GC = [{rabbit_mgmt_stats_gc:name(Table), {rabbit_mgmt_stats_gc, start_link, [Table]},
-           permanent, ?MAX_WAIT, worker, [rabbit_mgmt_stats_gc]}
+           permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_stats_gc]}
           || Table <- ?AGGR_TABLES],
     ProcGC = [{rabbit_mgmt_stats_gc:name(Table), {rabbit_mgmt_stats_gc, start_link, [Table]},
-           permanent, ?MAX_WAIT, worker, [rabbit_mgmt_stats_gc]}
+           permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_stats_gc]}
           || Table <- ?PROC_STATS_TABLES],
     DB = {rabbit_mgmt_db, {rabbit_mgmt_db, start_link, []},
-          permanent, ?MAX_WAIT, worker, [rabbit_mgmt_db]},
+          permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_db]},
     {ok, {{one_for_one, 10, 10}, [COLLECTOR, CCOLLECTOR, QCOLLECTOR, DB] ++ GC ++ ProcGC}}.
 
 start_link() ->

--- a/src/rabbit_mgmt_sup_sup.erl
+++ b/src/rabbit_mgmt_sup_sup.erl
@@ -68,4 +68,4 @@ init([]) ->
 
 sup() ->
     {rabbit_mgmt_sup, {rabbit_mgmt_sup, start_link, []},
-     temporary, ?MAX_WAIT, supervisor, [rabbit_mgmt_sup]}.
+     temporary, ?SUPERVISOR_WAIT, supervisor, [rabbit_mgmt_sup]}.


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-server#541
Replace `MAX_WAIT` with `WORKER_WAIT` for workers and with `SUPERVISOR_WAIT` for supervisors.