### PR TITLE
Use the new `rand_compat` module to transition from `random` to `rand`

### DIFF
--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -2018,7 +2018,7 @@ spawn_invalid(_Config, 0) ->
 spawn_invalid(Config, N) ->
     Self = self(),
     spawn(fun() ->
-                  timer:sleep(random:uniform(250)),
+                  timer:sleep(rand_compat:uniform(250)),
                   {ok, Sock} = gen_tcp:connect("localhost", amqp_port(Config), [list]),
                   ok = gen_tcp:send(Sock, "Some Data"),
                   receive_msg(Self)


### PR DESCRIPTION
References rabbitmq/rabbitmq-server#860.
[#122335241]