### PR TITLE
Fixed regression from performance improvements

### DIFF
--- a/src/rabbit_mgmt_db.erl
+++ b/src/rabbit_mgmt_db.erl
@@ -488,11 +488,10 @@ detail_and_basic_stats_fun(Type, Ranges, {IdType, FineSpecs}, Interval) ->
     F = detail_stats_fun(Ranges, {IdType, FineSpecs}, Interval),
     fun (Props) ->
             Id = id_lookup(IdType, Props),
-            BasicStatsRaw = ets:select(Type, [{{{{'$1', '$2'}, '$3'}, '$4', '_'},
+            BasicStats = ets:select(Type, [{{{{'$1', '$2'}, '$3'}, '$4', '_'},
                                                [{'==', '$1', Id},
                                                 {'==', '$3', stats}],
                                                [{{'$2', '$4'}}]}]),
-            BasicStats = [{K, V} || [K,V] <- BasicStatsRaw],
             [{K, Items}] = F(Props), %% [1]
             Items2 = [case lists:keyfind(id_lookup(IdType, Item), 1, BasicStats) of
                           false -> Item;


### PR DESCRIPTION
Fixes #250 
There was a regression from performance improvements in reading `node_node_stats` https://github.com/rabbitmq/rabbitmq-management/pull/101