### PR TITLE
Accept any content-type

### DIFF
--- a/src/rabbit_mgmt_wm_bindings.erl
+++ b/src/rabbit_mgmt_wm_bindings.erl
@@ -54,7 +54,7 @@ resource_exists(ReqData, {Mode, Context}) ->
     end.
 
 content_types_accepted(ReqData, Context) ->
-   {[{<<"application/json">>, accept_content}], ReqData, Context}.
+    {[{'*', accept_content}], ReqData, Context}.
 
 allowed_methods(ReqData, {Mode, Context}) ->
     {case Mode of

--- a/src/rabbit_mgmt_wm_cluster_name.erl
+++ b/src/rabbit_mgmt_wm_cluster_name.erl
@@ -38,7 +38,7 @@ content_types_provided(ReqData, Context) ->
    {[{<<"application/json">>, to_json}], ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
-   {[{<<"application/json">>, accept_content}], ReqData, Context}.
+   {[{'*', accept_content}], ReqData, Context}.
 
 allowed_methods(ReqData, Context) ->
     {[<<"HEAD">>, <<"GET">>, <<"PUT">>, <<"OPTIONS">>], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_exchange.erl
+++ b/src/rabbit_mgmt_wm_exchange.erl
@@ -39,7 +39,7 @@ content_types_provided(ReqData, Context) ->
    {[{<<"application/json">>, to_json}], ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
-   {[{<<"application/json">>, accept_content}], ReqData, Context}.
+    {[{'*', accept_content}], ReqData, Context}.
 
 allowed_methods(ReqData, Context) ->
     {[<<"HEAD">>, <<"GET">>, <<"PUT">>, <<"DELETE">>, <<"OPTIONS">>], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_permission.erl
+++ b/src/rabbit_mgmt_wm_permission.erl
@@ -39,7 +39,7 @@ content_types_provided(ReqData, Context) ->
    {[{<<"application/json">>, to_json}], ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
-   {[{<<"application/json">>, accept_content}], ReqData, Context}.
+    {[{'*', accept_content}], ReqData, Context}.
 
 allowed_methods(ReqData, Context) ->
     {[<<"HEAD">>, <<"GET">>, <<"PUT">>, <<"DELETE">>, <<"OPTIONS">>], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_queue.erl
+++ b/src/rabbit_mgmt_wm_queue.erl
@@ -39,7 +39,7 @@ content_types_provided(ReqData, Context) ->
    {[{<<"application/json">>, to_json}], ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
-   {[{<<"application/json">>, accept_content}], ReqData, Context}.
+    {[{'*', accept_content}], ReqData, Context}.
 
 allowed_methods(ReqData, Context) ->
     {[<<"HEAD">>, <<"GET">>, <<"PUT">>, <<"DELETE">>, <<"OPTIONS">>], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_user.erl
+++ b/src/rabbit_mgmt_wm_user.erl
@@ -41,7 +41,7 @@ content_types_provided(ReqData, Context) ->
    {[{<<"application/json">>, to_json}], ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
-   {[{<<"application/json">>, accept_content}], ReqData, Context}.
+    {[{'*', accept_content}], ReqData, Context}.
 
 allowed_methods(ReqData, Context) ->
     {[<<"HEAD">>, <<"GET">>, <<"PUT">>, <<"DELETE">>, <<"OPTIONS">>], ReqData, Context}.


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-management/issues/258 

Tested using `hole`
```
➜  hole git:(master) ✗ go test -v
=== RUN   TestRabbitHole
Running Suite: Rabbithole Suite
===============================
Random Seed: 1469026585
Will run 52 of 52 specs

••••••••••••••••••••••••••••••••••••••••••••••••••••
Ran 52 of 52 Specs in 13.169 seconds
SUCCESS! -- 52 Passed | 0 Failed | 0 Pending | 0 Skipped --- PASS: TestRabbitHole (13.17s)
PASS
```


`hop` tests passed for `Unsupported media type 415 response code` but there are still problems when the tests try to access to a deleted resource:

```
om.rabbitmq.http.client.ClientSpec > PUT /api/permissions/{vhost}/:user when vhost DOES NOT exist FAILED
    org.springframework.web.client.ResourceAccessException: I/O error on PUT request for "http://127.0.0.1:15672/api/users/hop-user1":null; nested exception is org.apache.http.client.ClientProtocolException
        at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:584)
        
        ...when vhost DOES NOT exist(ClientSpec.groovy:990)
```

I think because it is raised a `ResourceAccessException`  and [here](https://github.com/rabbitmq/hop/blob/master/src/main/java/com/rabbitmq/http/client/Client.java#L532)  it is not handled. (Could be ?)
 