### PR TITLE
Don't assume connection_closed details only contain a pid

### DIFF
--- a/src/rabbit_mgmt_event_collector_utils.erl
+++ b/src/rabbit_mgmt_event_collector_utils.erl
@@ -91,7 +91,8 @@ handle_event(#event{type = connection_stats, props = Stats,
                  ?COARSE_CONN_STATS, ?PROCESS_STATS, State);
 
 handle_event(Event = #event{type  = connection_closed,
-                            props = [{pid, Pid}]}, _State) ->
+                            props = Stats}, _State) ->
+        Pid = rabbit_misc:pget(pid, Stats),
     delete_samples(connection_stats, Pid),
     handle_deleted(connection_stats, Event);
 


### PR DESCRIPTION
They now include connection name and node, so the function head
in question never matched and connections kept piling up in the stats DB.

Part of https://github.com/rabbitmq/rabbitmq-server/issues/500.