### PR TITLE
removed reductions key on rabbit_mgmt_format

### DIFF
--- a/src/rabbit_mgmt_format.erl
+++ b/src/rabbit_mgmt_format.erl
@@ -48,6 +48,8 @@ format(Stats, {Fs, false}) ->
     lists:concat([Fs(Stat) || {_Name, Value} = Stat <- Stats,
                               Value =/= unknown]).
 
+format_queue_stats({reductions, _}) ->
+    [];
 format_queue_stats({exclusive_consumer_pid, _}) ->
     [];
 format_queue_stats({slave_pids, ''}) ->

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -60,6 +60,7 @@ groups() ->
                                multiple_invalid_connections_test,
                                exchanges_test,
                                queues_test,
+                               queues_well_formed_json_test,
                                bindings_test,
                                bindings_post_test,
                                bindings_e2e_test,
@@ -528,6 +529,23 @@ queues_test(Config) ->
     http_delete(Config, "/queues/%2f/baz", ?NO_CONTENT),
     http_delete(Config, "/queues/%2f/foo", ?NOT_FOUND),
     http_get(Config, "/queues/badvhost", ?NOT_FOUND),
+    passed.
+
+queues_well_formed_json_test(Config) ->
+    %% TODO This test should be extended to the whole API
+    Good = [{durable, true}],
+    http_put(Config, "/queues/%2f/foo", Good, [?CREATED, ?NO_CONTENT]),
+    http_put(Config, "/queues/%2f/baz", Good, [?CREATED, ?NO_CONTENT]),
+
+    Queues = http_get(Config, "/queues/%2f"),
+    %% Ensure keys are unique
+    [begin
+	 Sorted = lists:sort(Q),
+	 Sorted = lists:usort(Q)
+     end || Q <- Queues],
+
+    http_delete(Config, "/queues/%2f/foo", ?NO_CONTENT),
+    http_delete(Config, "/queues/%2f/baz", ?NO_CONTENT),
     passed.
 
 bindings_test(Config) ->


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-management/issues/278

- Tested with `hole`.
- Manually tested using:
   `curl -X GET -u guest:guest http://localhost:15672/api/queues/ | grep "reductions"`
 