### PR TITLE
Allow giving path when using #/login

### DIFF
--- a/priv/www/js/main.js
+++ b/priv/www/js/main.js
@@ -33,6 +33,20 @@ function login_route () {
     // we've changed url.
 }
 
+function login_route_path() {
+  var params = (''+this.params['splat']).split('/');
+  var user = params.shift();
+  var pass = params.shift();
+  var userpass = '' + user + ':' + pass,
+        location = window.location.href,
+        hash = window.location.hash;
+    set_auth_pref(decodeURIComponent(userpass));
+    location = location.substr(0, location.length - hash.length) + '#/' + params.join('/');
+    //alert(location);
+    check_login();
+    window.location.replace(location);
+}
+
 function start_app_login() {
     app = new Sammy.Application(function () {
         this.put('#/login', function() {
@@ -42,6 +56,7 @@ function start_app_login() {
             check_login();
         });
         this.get('#/login/:username/:password', login_route);
+        this.get(/\#\/login\/(.*)/, login_route_path);
     });
     app.run();
     if (get_pref('auth') != null) {


### PR DESCRIPTION
In certain cases we would like to allow our users to navigate to specific view after logging in.
e.g.: 
`/#/login/user/password/exchanges/rmq-stresstest/amq.direct`

We add new rule for login GET that navigates to the tail of the url 
after successful login.