### PR TITLE
Fix CORS preflight requests

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -125,6 +125,12 @@ is_authorized_policies(ReqData, Context) ->
                   end).
 
 is_authorized(ReqData, Context, ErrorMsg, Fun) ->
+    case cowboy_req:method(ReqData) of
+        {<<"OPTIONS">>, _} -> {true, ReqData, Context};
+        _ -> is_authorized1(ReqData, Context, ErrorMsg, Fun)
+    end.
+
+is_authorized1(ReqData, Context, ErrorMsg, Fun) ->
     case cowboy_req:parse_header(<<"authorization">>, ReqData) of
         {ok, {<<"basic">>, {Username, Password}}, _} ->
             is_authorized(ReqData, Context,

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -2030,8 +2030,8 @@ cors_test(Config) ->
     false = lists:keymember("access-control-allow-methods", 1, HdGetCORS),
     false = lists:keymember("access-control-allow-headers", 1, HdGetCORS),
     %% We should receive allow-origin, allow-credentials and allow-methods from OPTIONS.
-    {ok, {_, HdOptionsCORS, _}} = req(Config, options, "/overview",
-                                      [{"origin", "http://rabbitmq.com"}, auth_header("guest", "guest")]),
+    {ok, {{_, 200, _}, HdOptionsCORS, _}} = req(Config, options, "/overview",
+                                                [{"origin", "http://rabbitmq.com"}]),
     true = lists:keymember("access-control-allow-origin", 1, HdOptionsCORS),
     true = lists:keymember("access-control-allow-credentials", 1, HdOptionsCORS),
     false = lists:keymember("access-control-expose-headers", 1, HdOptionsCORS),


### PR DESCRIPTION
Fix for master for https://github.com/rabbitmq/rabbitmq-management/issues/301

Credentials are never sent with preflight requests, and preflight
requests are only accepted if they return successfully (eg 200).
We returned a 401 when credentials were missing so browsers rejected
the response.