### PR TITLE
rabbit_mgmt_wm_queue_get: Accept any Content-Type in the request body

### DIFF
--- a/src/rabbit_mgmt_wm_queue_get.erl
+++ b/src/rabbit_mgmt_wm_queue_get.erl
@@ -47,7 +47,7 @@ resource_exists(ReqData, Context) ->
      end, ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
-   {[{<<"application/json">>, accept_content}], ReqData, Context}.
+   {[{'*', accept_content}], ReqData, Context}.
 
 accept_content(ReqData, Context) ->
     rabbit_mgmt_util:post_respond(do_it(ReqData, Context)).


### PR DESCRIPTION
Internally, it only supports `application/json`, but historically, it ignored the Content-Type header and parsed the body anyway. This commit restores that behavior.

This fixes the "Get message(s)" button from the Web UI for instance: it set the Content-Type to `text/plain`.

[#135932951]