### PR TITLE
Use cleaner vhost limit listing API

### DIFF
--- a/src/rabbit_mgmt_wm_limits.erl
+++ b/src/rabbit_mgmt_wm_limits.erl
@@ -62,8 +62,10 @@ limits(ReqData, Context) ->
               || {VHost, Value} <- rabbit_vhost_limit:list(),
                  lists:member(VHost, VisibleVhosts) ];
         VHost when is_binary(VHost) ->
-            [ [{vhost, AVHost}, {value, Value}]
-	      || {AVHost, Value} <- rabbit_vhost_limit:list(VHost)]
+            case rabbit_vhost_limit:list(VHost) of
+                []    -> [];
+                Value -> [[{vhost, VHost}, {value, Value}]]
+            end
     end.
 %%--------------------------------------------------------------------
 

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -2181,7 +2181,6 @@ vhost_limits_list_test(Config) ->
 
     Limits1 =  [#{vhost => <<"limit_test_vhost_1">>,
                   value => #{'max-connections' => 100, 'max-queues' => 100}}],
-
     Limits2 =  [#{vhost => <<"limit_test_vhost_2">>,
 		  value => #{'max-connections' => 200}}],
 
@@ -2272,7 +2271,7 @@ vhost_limit_set_test(Config) ->
     Limits4 = [#{vhost => <<"limit_test_vhost_1">>,
         value => #{'max-queues' => 100}}],
     Limits4 = http_get(Config, "/vhost-limits/limit_test_vhost_1", ?OK),
-    
+
     %% Only admin can clear limits
     http_delete(Config, "/vhost-limits/limit_test_vhost_1/max-queues", Vhost1User, Vhost1User, ?NOT_AUTHORISED),
 


### PR DESCRIPTION
Support for rabbitmq/rabbitmq-server#1083

Return vhost in `vhost-limits/vhost` by management API.

Related to #326
Related to rabbitmq/rabbitmq-cli#165