### PR TITLE
Remove exchange from the apply-to options when

### DIFF
--- a/priv/www/js/tmpl/policies.ejs
+++ b/priv/www/js/tmpl/policies.ejs
@@ -225,8 +225,6 @@
           <th><label>Apply to:</label></th>
           <td>
             <select name="apply-to">
-              <option value="all">Exchanges and queues</option>
-              <option value="exchanges">Exchanges</option>
               <option value="queues">Queues</option>
             </select>
           </td>


### PR DESCRIPTION
creating/updating operator policies.
Fixes #330 