### PR TITLE
Make HTTP API stats.html link relative

### DIFF
--- a/priv/www/api/index.html
+++ b/priv/www/api/index.html
@@ -54,7 +54,7 @@
     list of subfields separated by dots. See the example below.</p>
 
     <p>Most of the GET queries return many fields per
-    object. See <a href="/doc/stats.html">the separate stats
+    object. See <a href="../doc/stats.html">the separate stats
     documentation</a>.</p>
     
     <h2>Examples</h2>


### PR DESCRIPTION
Otherwise this link is broken on the page
https://raw.githack.com/rabbitmq/rabbitmq-management/rabbitmq_v3_6_6/priv/www/api/index.html
(currently mentioned at http://www.rabbitmq.com/management.html )

I've tested it, relative link also works when the doc is show by management plugin in a live rabbit instance.