### PR TITLE
Remove unused define

### DIFF
--- a/src/rabbit_mgmt_stats.erl
+++ b/src/rabbit_mgmt_stats.erl
@@ -21,7 +21,6 @@
 
 -export([format_range/6]).
 
--define(ALWAYS_REPORT, [queue_msg_counts, coarse_node_stats]).
 -define(MICRO_TO_MILLI, 1000).
 
 -type maybe_range() :: no_range | #range{}.


### PR DESCRIPTION
Looks like `queue_msg_counts`  and  `coarse_node_stats` are used directly at proper places.