### PR TITLE
Add support for non-JSON encoding of replies

### DIFF
--- a/src/rabbit_mgmt_wm_aliveness_test.erl
+++ b/src/rabbit_mgmt_wm_aliveness_test.erl
@@ -36,7 +36,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {case rabbit_mgmt_util:vhost(ReqData) of

--- a/src/rabbit_mgmt_wm_binding.erl
+++ b/src/rabbit_mgmt_wm_binding.erl
@@ -35,7 +35,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
    {[{'*', accept_content}], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_bindings.erl
+++ b/src/rabbit_mgmt_wm_bindings.erl
@@ -36,7 +36,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 %% The current version of Cowboy forces us to report the resource doesn't
 %% exist here in order to get a 201 response. It seems Cowboy confuses the

--- a/src/rabbit_mgmt_wm_channel.erl
+++ b/src/rabbit_mgmt_wm_channel.erl
@@ -34,7 +34,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     case channel(ReqData) of

--- a/src/rabbit_mgmt_wm_channels.erl
+++ b/src/rabbit_mgmt_wm_channels.erl
@@ -36,7 +36,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 to_json(ReqData, Context) ->
     try

--- a/src/rabbit_mgmt_wm_channels_vhost.erl
+++ b/src/rabbit_mgmt_wm_channels_vhost.erl
@@ -38,7 +38,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {rabbit_vhost:exists(rabbit_mgmt_util:id(vhost, ReqData)), ReqData, Context}.

--- a/src/rabbit_mgmt_wm_cluster_name.erl
+++ b/src/rabbit_mgmt_wm_cluster_name.erl
@@ -35,7 +35,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
    {[{'*', accept_content}], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_connection.erl
+++ b/src/rabbit_mgmt_wm_connection.erl
@@ -34,7 +34,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 allowed_methods(ReqData, Context) ->
     {[<<"HEAD">>, <<"GET">>, <<"DELETE">>, <<"OPTIONS">>], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_connection_channels.erl
+++ b/src/rabbit_mgmt_wm_connection_channels.erl
@@ -34,7 +34,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     case rabbit_mgmt_wm_connection:conn(ReqData) of

--- a/src/rabbit_mgmt_wm_connections.erl
+++ b/src/rabbit_mgmt_wm_connections.erl
@@ -36,7 +36,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 to_json(ReqData, Context) ->
     try

--- a/src/rabbit_mgmt_wm_connections_vhost.erl
+++ b/src/rabbit_mgmt_wm_connections_vhost.erl
@@ -38,7 +38,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {rabbit_vhost:exists(rabbit_mgmt_util:id(vhost, ReqData)), ReqData, Context}.

--- a/src/rabbit_mgmt_wm_consumers.erl
+++ b/src/rabbit_mgmt_wm_consumers.erl
@@ -35,7 +35,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {case rabbit_mgmt_util:vhost(ReqData) of

--- a/src/rabbit_mgmt_wm_definitions.erl
+++ b/src/rabbit_mgmt_wm_definitions.erl
@@ -40,7 +40,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
    {[{<<"application/json">>, accept_json},

--- a/src/rabbit_mgmt_wm_exchange.erl
+++ b/src/rabbit_mgmt_wm_exchange.erl
@@ -36,7 +36,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
     {[{'*', accept_content}], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_exchange_publish.erl
+++ b/src/rabbit_mgmt_wm_exchange_publish.erl
@@ -38,7 +38,7 @@ allowed_methods(ReqData, Context) ->
     {[<<"POST">>, <<"OPTIONS">>], ReqData, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {case rabbit_mgmt_wm_exchange:exchange(ReqData) of

--- a/src/rabbit_mgmt_wm_exchanges.erl
+++ b/src/rabbit_mgmt_wm_exchanges.erl
@@ -34,7 +34,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {case exchanges0(ReqData) of

--- a/src/rabbit_mgmt_wm_extensions.erl
+++ b/src/rabbit_mgmt_wm_extensions.erl
@@ -33,7 +33,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 to_json(ReqData, Context) ->
     Modules = rabbit_mgmt_dispatcher:modules([]),

--- a/src/rabbit_mgmt_wm_global_parameter.erl
+++ b/src/rabbit_mgmt_wm_global_parameter.erl
@@ -37,7 +37,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
    {[{'*', accept_content}], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_global_parameters.erl
+++ b/src/rabbit_mgmt_wm_global_parameters.erl
@@ -33,7 +33,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 to_json(ReqData, Context) ->
     rabbit_mgmt_util:reply_list(basic(), ReqData, Context).

--- a/src/rabbit_mgmt_wm_healthchecks.erl
+++ b/src/rabbit_mgmt_wm_healthchecks.erl
@@ -32,7 +32,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {case node0(ReqData) of

--- a/src/rabbit_mgmt_wm_node.erl
+++ b/src/rabbit_mgmt_wm_node.erl
@@ -34,7 +34,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {case node0(ReqData) of

--- a/src/rabbit_mgmt_wm_node_memory.erl
+++ b/src/rabbit_mgmt_wm_node_memory.erl
@@ -33,7 +33,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {node_exists(ReqData, get_node(ReqData)), ReqData, Context}.

--- a/src/rabbit_mgmt_wm_node_memory_ets.erl
+++ b/src/rabbit_mgmt_wm_node_memory_ets.erl
@@ -33,7 +33,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {node_exists(ReqData, get_node(ReqData)), ReqData, Context}.

--- a/src/rabbit_mgmt_wm_nodes.erl
+++ b/src/rabbit_mgmt_wm_nodes.erl
@@ -34,7 +34,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 to_json(ReqData, Context) ->
     try

--- a/src/rabbit_mgmt_wm_overview.erl
+++ b/src/rabbit_mgmt_wm_overview.erl
@@ -35,7 +35,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 to_json(ReqData, Context = #context{user = User = #user{tags = Tags}}) ->
     RatesMode = rabbit_mgmt_agent_config:get_env(rates_mode),

--- a/src/rabbit_mgmt_wm_parameter.erl
+++ b/src/rabbit_mgmt_wm_parameter.erl
@@ -38,7 +38,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
    {[{'*', accept_content}], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_parameters.erl
+++ b/src/rabbit_mgmt_wm_parameters.erl
@@ -35,7 +35,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {case basic(ReqData) of

--- a/src/rabbit_mgmt_wm_permission.erl
+++ b/src/rabbit_mgmt_wm_permission.erl
@@ -36,7 +36,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
     {[{'*', accept_content}], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_permissions.erl
+++ b/src/rabbit_mgmt_wm_permissions.erl
@@ -34,7 +34,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 to_json(ReqData, Context) ->
     rabbit_mgmt_util:reply_list(permissions(), ["vhost", "user"],

--- a/src/rabbit_mgmt_wm_permissions_user.erl
+++ b/src/rabbit_mgmt_wm_permissions_user.erl
@@ -34,7 +34,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {case rabbit_mgmt_wm_user:user(ReqData) of

--- a/src/rabbit_mgmt_wm_permissions_vhost.erl
+++ b/src/rabbit_mgmt_wm_permissions_vhost.erl
@@ -34,7 +34,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {rabbit_vhost:exists(rabbit_mgmt_wm_vhost:id(ReqData)), ReqData, Context}.

--- a/src/rabbit_mgmt_wm_policies.erl
+++ b/src/rabbit_mgmt_wm_policies.erl
@@ -34,7 +34,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {case basic(ReqData) of

--- a/src/rabbit_mgmt_wm_policy.erl
+++ b/src/rabbit_mgmt_wm_policy.erl
@@ -38,7 +38,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
    {[{'*', accept_content}], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_queue.erl
+++ b/src/rabbit_mgmt_wm_queue.erl
@@ -36,7 +36,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
     {[{'*', accept_content}], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_queue_get.erl
+++ b/src/rabbit_mgmt_wm_queue_get.erl
@@ -38,7 +38,7 @@ allowed_methods(ReqData, Context) ->
     {[<<"POST">>, <<"OPTIONS">>], ReqData, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {case rabbit_mgmt_wm_queue:queue(ReqData) of

--- a/src/rabbit_mgmt_wm_queues.erl
+++ b/src/rabbit_mgmt_wm_queues.erl
@@ -34,7 +34,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {case queues0(ReqData) of

--- a/src/rabbit_mgmt_wm_user.erl
+++ b/src/rabbit_mgmt_wm_user.erl
@@ -38,7 +38,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
     {[{'*', accept_content}], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_users.erl
+++ b/src/rabbit_mgmt_wm_users.erl
@@ -36,7 +36,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 to_json(ReqData, Context) ->
     rabbit_mgmt_util:reply_list(users(), ReqData, Context).

--- a/src/rabbit_mgmt_wm_vhost.erl
+++ b/src/rabbit_mgmt_wm_vhost.erl
@@ -38,7 +38,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 content_types_accepted(ReqData, Context) ->
    {[{'*', accept_content}], ReqData, Context}.

--- a/src/rabbit_mgmt_wm_vhosts.erl
+++ b/src/rabbit_mgmt_wm_vhosts.erl
@@ -34,7 +34,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 to_json(ReqData, Context) ->
     try

--- a/src/rabbit_mgmt_wm_whoami.erl
+++ b/src/rabbit_mgmt_wm_whoami.erl
@@ -33,7 +33,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {rabbit_mgmt_util:json_like_handlers(to_json), ReqData, Context}.
 
 to_json(ReqData, Context = #context{user = User}) ->
     rabbit_mgmt_util:reply(rabbit_mgmt_format:user(User), ReqData, Context).

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -2085,7 +2085,7 @@ cors_test(Config) ->
     {ok, {_, HdNoCORS, _}} = req(Config, get, "/overview", [auth_header("guest", "guest")]),
     false = lists:keymember("access-control-allow-origin", 1, HdNoCORS),
     %% The Vary header should include "Origin" regardless of CORS configuration.
-    {_, "accept-encoding, origin"} = lists:keyfind("vary", 1, HdNoCORS),
+    {_, "accept, accept-encoding, origin"} = lists:keyfind("vary", 1, HdNoCORS),
     %% Enable CORS.
     rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env, [rabbitmq_management, cors_allow_origins, ["http://rabbitmq.com"]]),
     %% We should only receive allow-origin and allow-credentials from GET.


### PR DESCRIPTION
One of the low-hanging fruits in HTTP API optimization.
E.g. serializing information about 10000 queues:
- For JSON it takes 2 seconds on my machine and more than 1GB of RAM
- For BERT it takes 0.2 seconds and a negligible amount of RAM

If the approach in general is OK, I'm going to replace all other
instances of `<<"application/json">>` everywhere.