### PR TITLE
Add ability to skip sorting of results

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -255,6 +255,11 @@ reply_list_or_paginate(Facts, ReqData, Context) ->
 sort_list(Facts, Sorts) -> sort_list(Facts, Sorts, undefined, false,
   undefined).
 
+sort_list(Facts, _, [], _, _) ->
+    %% Do not sort when we are explicitly requsted to sort with an
+    %% empty sort columns list. Note that this clause won't match when
+    %% 'sort' parameter is not provided in a HTTP request at all.
+    Facts;
 sort_list(Facts, DefaultSorts, Sort, Reverse, Pagination) ->
     SortList = case Sort of
            undefined -> DefaultSorts;


### PR DESCRIPTION
Another low-hanging fruit for HTTP API optimization.

Allow user to specify empty sort parameter to avoid paying the sorting
cost. As for some applications (like monitoring) it doesn't matter
whether the result is sorted or not. And e.g. for 10000 queues
performing the sort using the default sorting order costs ~0.3 second
on my machine.