### PR TITLE
Support maps in deep-sorting

### DIFF
--- a/priv/www/js/tmpl/connections.ejs
+++ b/priv/www/js/tmpl/connections.ejs
@@ -1,7 +1,7 @@
 <h1>Connections</h1>
 <div class="section">
  <%= pagiante_ui(connections, 'connections') %>
-</div> 
+</div>
 <div class="updatable">
 <% if (connections.items.length > 0) { %>
 <table class="list">
@@ -16,7 +16,7 @@
 <% if (vhosts_interesting) { %>
     <th><%= fmt_sort('Virtual host', 'vhost') %></th>
 <% } %>
-    <th><%= fmt_sort('Name',           'client_properties.connection_name;name') %></th>
+    <th><%= fmt_sort('Name',           'client_properties.connection_name') %></th>
 <% if (nodes_interesting) { %>
     <th><%= fmt_sort('Node',           'node') %></th>
 <% } %>

--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -437,7 +437,9 @@ get_dotted_value0([Key], Item) ->
 get_dotted_value0([Key | Keys], Item) ->
     get_dotted_value0(Keys, pget_bin(list_to_binary(Key), Item, [])).
 
-pget_bin(Key, List, Default) ->
+pget_bin(Key, Map, Default) when is_map(Map) ->
+    maps:get(Key, Map, Default);
+pget_bin(Key, List, Default) when is_list(List) ->
     case lists:partition(fun ({K, _V}) -> a2b(K) =:= Key end, List) of
         {[{_K, V}], _} -> V;
         {[],        _} -> Default


### PR DESCRIPTION
Fixes #372 

Add support for maps in sorting code. Do not use `;` separated sort fields, because they don't work.