### PR TITLE
Add link to password generation documentation

### DIFF
--- a/priv/www/api/index.html
+++ b/priv/www/api/index.html
@@ -663,10 +663,12 @@ or:
 <pre>{"password_hash":"2lmoth8l4H0DViLaK9Fxi6l9ds8=", "tags":"administrator"}</pre>
         The <code>tags</code> key is mandatory. Either
         <code>password</code> or <code>password_hash</code>
-        must be set. Setting <code>password_hash</code> to "" will ensure the
+        must be set. Setting <code>password_hash</code> to <code>""</code> will ensure the
         user cannot use a password to log in. <code>tags</code> is a
         comma-separated list of tags for the user. Currently recognised tags
-        are "administrator", "monitoring" and "management".
+        are <code>administrator</code>, <code>monitoring</code> and <code>management</code>.
+        <code>password_hash</code> must be generated using the algorithm described
+        <a href="http://rabbitmq.com/passwords.html#password-generation">here</a>.
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
See rabbitmq/rabbitmq-management#386 for the previous PR that lead to this.

Requires rabbitmq/rabbitmq-website#376