### PR TITLE
Ensure cowboy Req is returned from `with_decode`

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -208,23 +208,15 @@ responder_map(FunctionName) ->
 reply(Facts, ReqData, Context) ->
     reply0(extract_columns(Facts, ReqData), ReqData, Context).
 
-reply0(Facts, ReqData0, Context) ->
-    ReqData =
-        case cowboy_req:method(ReqData0) of
-            {<<"POST">>, _} ->
-                % after a state changing operation it is best to close
-                % the keep-alive connection
-                set_resp_header(<<"Connection">>, "close", ReqData0);
-            _ -> ReqData0
-        end,
+reply0(Facts, ReqData, Context) ->
     ReqData1 = set_resp_header(<<"Cache-Control">>, "no-cache", ReqData),
     try
         case cowboy_req:meta(media_type, ReqData1) of
             {{<<"application">>, <<"bert">>, _}, _} ->
                 {term_to_binary(Facts), ReqData1, Context};
             _ ->
-                {mochijson2:encode(rabbit_mgmt_format:format_nulls(Facts)), ReqData1,
-                 Context}
+                {mochijson2:encode(rabbit_mgmt_format:format_nulls(Facts)),
+                 ReqData1, Context}
         end
     catch exit:{json_encode, E} ->
             Error = iolist_to_binary(
@@ -522,7 +514,7 @@ with_decode(Keys, Body, ReqData, Context, Fun) ->
     case decode(Keys, Body) of
         {error, Reason}    -> bad_request(Reason, ReqData, Context);
         {ok, Values, JSON} -> try
-                                  Fun(Values, JSON)
+                                  Fun(Values, JSON, ReqData)
                               catch {error, Error} ->
                                       bad_request(Error, ReqData, Context)
                               end

--- a/src/rabbit_mgmt_wm_cluster_name.erl
+++ b/src/rabbit_mgmt_wm_cluster_name.erl
@@ -50,9 +50,9 @@ to_json(ReqData, Context) ->
     rabbit_mgmt_util:reply(
       [{name, rabbit_nodes:cluster_name()}], ReqData, Context).
 
-accept_content(ReqData, Context) ->
+accept_content(ReqData0, Context) ->
     rabbit_mgmt_util:with_decode(
-      [name], ReqData, Context, fun([Name], _) ->
+      [name], ReqData0, Context, fun([Name], _, ReqData) ->
                                         rabbit_nodes:set_cluster_name(
                                           as_binary(Name)),
                                         {true, ReqData, Context}

--- a/src/rabbit_mgmt_wm_exchange_publish.erl
+++ b/src/rabbit_mgmt_wm_exchange_publish.erl
@@ -52,12 +52,12 @@ content_types_accepted(ReqData, Context) ->
 accept_content(ReqData, Context) ->
     rabbit_mgmt_util:post_respond(do_it(ReqData, Context)).
 
-do_it(ReqData, Context) ->
-    VHost = rabbit_mgmt_util:vhost(ReqData),
-    X = rabbit_mgmt_util:id(exchange, ReqData),
+do_it(ReqData0, Context) ->
+    VHost = rabbit_mgmt_util:vhost(ReqData0),
+    X = rabbit_mgmt_util:id(exchange, ReqData0),
     rabbit_mgmt_util:with_decode(
-      [routing_key, properties, payload, payload_encoding], ReqData, Context,
-      fun ([RoutingKey, Props0, Payload0, Enc], _) when is_binary(Payload0) ->
+      [routing_key, properties, payload, payload_encoding], ReqData0, Context,
+      fun ([RoutingKey, Props0, Payload0, Enc], _, ReqData) when is_binary(Payload0) ->
               rabbit_mgmt_util:with_channel(
                 VHost, ReqData, Context,
                 fun (Ch) ->
@@ -85,7 +85,7 @@ do_it(ReqData, Context) ->
                                 bad(Err, ReqData, Context)
                         end
                 end);
-          ([_RoutingKey, _Props, _Payload, _Enc], _) ->
+          ([_RoutingKey, _Props, _Payload, _Enc], _, _ReqData) ->
               throw({error, payload_not_string})
       end).
 

--- a/src/rabbit_mgmt_wm_global_parameter.erl
+++ b/src/rabbit_mgmt_wm_global_parameter.erl
@@ -22,8 +22,6 @@
          delete_resource/2]).
 -export([variances/2]).
 
--import(rabbit_misc, [pget/2]).
-
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
 
 %%--------------------------------------------------------------------
@@ -55,10 +53,10 @@ to_json(ReqData, Context) ->
     rabbit_mgmt_util:reply(rabbit_mgmt_format:parameter(parameter(ReqData)),
                            ReqData, Context).
 
-accept_content(ReqData, Context) ->
+accept_content(ReqData0, Context) ->
     rabbit_mgmt_util:with_decode(
-      [value], ReqData, Context,
-      fun([Value], _) ->
+      [value], ReqData0, Context,
+      fun([Value], _, ReqData) ->
               case rabbit_runtime_parameters:set_global(
                      name(ReqData),rabbit_misc:json_to_term(Value)) of
                   ok ->

--- a/src/rabbit_mgmt_wm_parameter.erl
+++ b/src/rabbit_mgmt_wm_parameter.erl
@@ -22,8 +22,6 @@
          delete_resource/2]).
 -export([variances/2]).
 
--import(rabbit_misc, [pget/2]).
-
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 
@@ -57,14 +55,14 @@ to_json(ReqData, Context) ->
         rabbit_mgmt_wm_parameters:fix_shovel_publish_properties(parameter(ReqData))),
                            ReqData, Context).
 
-accept_content(ReqData, Context = #context{user = User}) ->
-    case rabbit_mgmt_util:vhost(ReqData) of
+accept_content(ReqData0, Context = #context{user = User}) ->
+    case rabbit_mgmt_util:vhost(ReqData0) of
         not_found ->
-            rabbit_mgmt_util:not_found(vhost_not_found, ReqData, Context);
+            rabbit_mgmt_util:not_found(vhost_not_found, ReqData0, Context);
         VHost ->
             rabbit_mgmt_util:with_decode(
-              [value], ReqData, Context,
-              fun([Value], _) ->
+              [value], ReqData0, Context,
+              fun([Value], _, ReqData) ->
                       case rabbit_runtime_parameters:set(
                              VHost, component(ReqData), name(ReqData),
                              rabbit_misc:json_to_term(Value), User) of

--- a/src/rabbit_mgmt_wm_permission.erl
+++ b/src/rabbit_mgmt_wm_permission.erl
@@ -54,17 +54,17 @@ resource_exists(ReqData, Context) ->
 to_json(ReqData, Context) ->
     rabbit_mgmt_util:reply(perms(ReqData), ReqData, Context).
 
-accept_content(ReqData, Context) ->
-    case perms(ReqData) of
+accept_content(ReqData0, Context) ->
+    case perms(ReqData0) of
          not_found ->
             rabbit_mgmt_util:bad_request(vhost_or_user_not_found,
-                                         ReqData, Context);
+                                         ReqData0, Context);
          _         ->
-            User = rabbit_mgmt_util:id(user, ReqData),
-            VHost = rabbit_mgmt_util:id(vhost, ReqData),
+            User = rabbit_mgmt_util:id(user, ReqData0),
+            VHost = rabbit_mgmt_util:id(vhost, ReqData0),
             rabbit_mgmt_util:with_decode(
-              [configure, write, read], ReqData, Context,
-              fun([Conf, Write, Read], _) ->
+              [configure, write, read], ReqData0, Context,
+              fun([Conf, Write, Read], _, ReqData) ->
                       rabbit_auth_backend_internal:set_permissions(
                         User, VHost, Conf, Write, Read),
                       {true, ReqData, Context}

--- a/src/rabbit_mgmt_wm_policy.erl
+++ b/src/rabbit_mgmt_wm_policy.erl
@@ -22,8 +22,6 @@
          delete_resource/2]).
 -export([variances/2]).
 
--import(rabbit_misc, [pget/2]).
-
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 
@@ -55,14 +53,14 @@ resource_exists(ReqData, Context) ->
 to_json(ReqData, Context) ->
     rabbit_mgmt_util:reply(policy(ReqData), ReqData, Context).
 
-accept_content(ReqData, Context) ->
-    case rabbit_mgmt_util:vhost(ReqData) of
+accept_content(ReqData0, Context) ->
+    case rabbit_mgmt_util:vhost(ReqData0) of
         not_found ->
-            rabbit_mgmt_util:not_found(vhost_not_found, ReqData, Context);
+            rabbit_mgmt_util:not_found(vhost_not_found, ReqData0, Context);
         VHost ->
             rabbit_mgmt_util:with_decode(
-              [pattern, definition], ReqData, Context,
-              fun([Pattern, Definition], Body) ->
+              [pattern, definition], ReqData0, Context,
+              fun([Pattern, Definition], Body, ReqData) ->
                       case rabbit_policy:set(
                              VHost, name(ReqData), Pattern,
                              rabbit_misc:json_to_term(Definition),

--- a/src/rabbit_mgmt_wm_queue_actions.erl
+++ b/src/rabbit_mgmt_wm_queue_actions.erl
@@ -48,12 +48,12 @@ content_types_accepted(ReqData, Context) ->
 accept_content(ReqData, Context) ->
     rabbit_mgmt_util:post_respond(do_it(ReqData, Context)).
 
-do_it(ReqData, Context) ->
-    VHost = rabbit_mgmt_util:vhost(ReqData),
-    QName = rabbit_mgmt_util:id(queue, ReqData),
+do_it(ReqData0, Context) ->
+    VHost = rabbit_mgmt_util:vhost(ReqData0),
+    QName = rabbit_mgmt_util:id(queue, ReqData0),
     rabbit_mgmt_util:with_decode(
-      [action], ReqData, Context,
-      fun([Action], _Body) ->
+      [action], ReqData0, Context,
+      fun([Action], _Body, ReqData) ->
               rabbit_amqqueue:with(
                 rabbit_misc:r(VHost, queue, QName),
                 fun(Q) -> action(Action, Q, ReqData, Context) end)

--- a/src/rabbit_mgmt_wm_queue_get.erl
+++ b/src/rabbit_mgmt_wm_queue_get.erl
@@ -52,12 +52,12 @@ content_types_accepted(ReqData, Context) ->
 accept_content(ReqData, Context) ->
     rabbit_mgmt_util:post_respond(do_it(ReqData, Context)).
 
-do_it(ReqData, Context) ->
-    VHost = rabbit_mgmt_util:vhost(ReqData),
-    Q = rabbit_mgmt_util:id(queue, ReqData),
+do_it(ReqData0, Context) ->
+    VHost = rabbit_mgmt_util:vhost(ReqData0),
+    Q = rabbit_mgmt_util:id(queue, ReqData0),
     rabbit_mgmt_util:with_decode(
-      [requeue, count, encoding], ReqData, Context,
-      fun([RequeueBin, CountBin, EncBin], Body) ->
+      [requeue, count, encoding], ReqData0, Context,
+      fun([RequeueBin, CountBin, EncBin], Body, ReqData) ->
               rabbit_mgmt_util:with_channel(
                 VHost, ReqData, Context,
                 fun (Ch) ->

--- a/src/rabbit_mgmt_wm_user.erl
+++ b/src/rabbit_mgmt_wm_user.erl
@@ -57,11 +57,11 @@ to_json(ReqData, Context) ->
     rabbit_mgmt_util:reply(rabbit_mgmt_format:internal_user(User),
                            ReqData, Context).
 
-accept_content(ReqData, Context) ->
-    Username = rabbit_mgmt_util:id(user, ReqData),
+accept_content(ReqData0, Context) ->
+    Username = rabbit_mgmt_util:id(user, ReqData0),
     rabbit_mgmt_util:with_decode(
-      [], ReqData, Context,
-      fun(_, User) ->
+      [], ReqData0, Context,
+      fun(_, User, ReqData) ->
               put_user([{name, Username} | User]),
               {true, ReqData, Context}
       end).

--- a/src/rabbit_mgmt_wm_vhost.erl
+++ b/src/rabbit_mgmt_wm_vhost.erl
@@ -60,11 +60,11 @@ to_json(ReqData, Context) ->
             rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
     end.
 
-accept_content(ReqData, Context) ->
-    Name = id(ReqData),
+accept_content(ReqData0, Context) ->
+    Name = id(ReqData0),
     rabbit_mgmt_util:with_decode(
-      [], ReqData, Context,
-      fun(_, VHost) ->
+      [], ReqData0, Context,
+      fun(_, VHost, ReqData) ->
               put_vhost(Name, rabbit_mgmt_util:parse_bool(
                                 pget(tracing, VHost))),
               {true, ReqData, Context}

--- a/test/clustering_SUITE.erl
+++ b/test/clustering_SUITE.erl
@@ -16,6 +16,7 @@
 
 -module(clustering_SUITE).
 
+-include_lib("amqp_client/include/amqp_client.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("rabbit_common/include/rabbit_core_metrics.hrl").

--- a/test/clustering_prop_SUITE.erl
+++ b/test/clustering_prop_SUITE.erl
@@ -16,6 +16,7 @@
 
 -module(clustering_prop_SUITE).
 
+-include_lib("amqp_client/include/amqp_client.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("proper/include/proper.hrl").
 -include_lib("rabbit_common/include/rabbit_core_metrics.hrl").

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -16,6 +16,7 @@
 
 -module(rabbit_mgmt_http_SUITE).
 
+-include_lib("amqp_client/include/amqp_client.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("rabbitmq_ct_helpers/include/rabbit_mgmt_test.hrl").


### PR DESCRIPTION
Reversing initial fix in 74e9e36cf7a8baa9e5a0d6714fb7111dee5a37f8

Usages of `with_decode` closed over the ReqData and returned the
instance before the body decode. This had the effect of causing an error
after a  POST or PUT request had been issues on the same keep-alive
connection.