### PR TITLE
Augment queues after sorting (if possible)

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -315,8 +315,9 @@ unaugmented_reply_list_or_paginate(BasicFacts,
       ReqData, Context,
       fun(Pagination) ->
               DefaultSorts = ["vhost", "name"],
-              SortParam = merge_sorts_from_req(DefaultSorts, ReqData),
-              AugmentAfterPagination = is_pagination_requested(Pagination) andalso CanAugmentAfterPaginationPredicate(SortParam),
+              SortParam = get_value_param(<<"sort">>, ReqData),
+              MentionedSortColumns = lists:usort(merge_sorts(DefaultSorts, SortParam)),
+              AugmentAfterPagination = is_pagination_requested(Pagination) andalso CanAugmentAfterPaginationPredicate(MentionedSortColumns),
               FactsForPagination = maybe_augment_facts(not AugmentAfterPagination, AugmentFn, BasicFacts),
               SortedFacts = sort_list(
                               extract_columns_list(FactsForPagination, ReqData),
@@ -347,9 +348,6 @@ reply_list_or_paginate(Facts, ReqData, Context) ->
       fun(Pagination) ->
               reply_list(Facts, ["vhost", "name"], ReqData, Context, Pagination)
       end).
-
-merge_sorts_from_req(DefaultSorts, ReqData) ->
-    merge_sorts(DefaultSorts, get_value_param(<<"sort">>, ReqData)).
 
 merge_sorts(DefaultSorts, Extra) ->
     case Extra of

--- a/src/rabbit_mgmt_wm_queues.erl
+++ b/src/rabbit_mgmt_wm_queues.erl
@@ -73,11 +73,11 @@ augmented(ReqData, Context) ->
 %%--------------------------------------------------------------------
 %% Private helpers
 
-%% XXX Implement full check to accept all valid sorts, not only the default one
-is_sort_order_compatible_with_basic(["vhost", "name"]) ->
-    true;
-is_sort_order_compatible_with_basic(_) ->
-    false.
+is_sort_order_compatible_with_basic(MentionedSortColumns) ->
+    SafeColumns = ["vhost", "name", "durable", "auto_delete", "exclusive",
+                   "owner_pid", "arguments", "pid", "state"],
+    SafeColumnsSet = sets:from_list(SafeColumns),
+    sets:is_subset(sets:from_list(MentionedSortColumns), SafeColumnsSet).
 
 augment(Basic, ReqData) ->
     rabbit_mgmt_db:augment_queues(Basic, rabbit_mgmt_util:range_ceil(ReqData), basic).


### PR DESCRIPTION
Profiling shows that most expensive part of listing
queues/exchanges/channels etc. is calculating various rates using
exometer functionality.

Given that Web UI uses pagination and the default sort order (and some
other reasonable sort orders) actually doesn't require augmented data
to perform sorting and paging, sometimes we can postpone augmentation
until the data set is a lot smaller.

This patch lays basic groundwork for this approach and also implements
such a behavior for queues.

Test on my workstation shows that on a broker with 10000 warmed-up queues
reply time for a 100-items page with default sort orders drops from 6
seconds to 0.3 seconds. These are timings when
rabbit_mgmt_db:submit_cached/4 doesn't hit, and caching slightly
improves the situation. But this patch strives to get rid of this
overhead completely.