### PR TITLE
Manage topic permissions from the UI in user and vhost tabs

### DIFF
--- a/priv/www/js/dispatcher.js
+++ b/priv/www/js/dispatcher.js
@@ -154,7 +154,9 @@ dispatcher_add(function(sammy) {
                                                  'msg-rates-vhost',
                                                  'data-rates-vhost']}},
                     'permissions': '/vhosts/' + esc(this.params['id']) + '/permissions',
-                    'users': '/users/'},
+                    'topic_permissions': '/vhosts/' + esc(this.params['id']) + '/topic-permissions',
+                    'users': '/users/',
+                    'exchanges' : '/exchanges/' + esc(this.params['id'])},
                 'vhost', '#/vhosts');
         });
 
@@ -177,9 +179,12 @@ dispatcher_add(function(sammy) {
                                options: {sort:true}},
                      'permissions': '/permissions'}, 'users');
     sammy.get('#/users/:id', function() {
+        var vhosts = JSON.parse(sync_get('/vhosts'));
             render({'user': '/users/' + esc(this.params['id']),
                     'permissions': '/users/' + esc(this.params['id']) + '/permissions',
-                    'vhosts': '/vhosts/'}, 'user',
+                    'topic_permissions': '/users/' + esc(this.params['id']) + '/topic-permissions',
+                    'vhosts': '/vhosts/',
+                    'exchanges': '/exchanges/' + esc(vhosts[0].name)}, 'user',
                    '#/users');
         });
     sammy.put('#/users-add', function() {
@@ -205,6 +210,16 @@ dispatcher_add(function(sammy) {
         });
     sammy.del('#/permissions', function() {
             if (sync_delete(this, '/permissions/:vhost/:username'))
+                update();
+            return false;
+        });
+    sammy.put('#/topic-permissions', function() {
+            if (sync_put(this, '/topic-permissions/:vhost/:username'))
+                update();
+            return false;
+        });
+    sammy.del('#/topic-permissions', function() {
+            if (sync_delete(this, '/topic-permissions/:vhost/:username/:exchange'))
                 update();
             return false;
         });

--- a/priv/www/js/main.js
+++ b/priv/www/js/main.js
@@ -223,6 +223,7 @@ function update_manual(div, query) {
         path = current_reqs['node']['path'] + '?' + query + '=true';
         template = query;
     }
+
     var data = JSON.parse(sync_get(path));
 
     replace_content(div, format(template, data));
@@ -598,6 +599,12 @@ function postprocess() {
                 $('#' + param + '-div').slideUp(100);
             }
         }
+    });
+    $('.list-exchanges').change(function() {
+        var selected = $(this).val();
+        var data = {'exchanges' : JSON.parse(sync_get('/exchanges/' + esc(selected)))};
+        replace_content('list-exchanges', format('list-exchanges', data));
+        postprocess_partial();
     });
     $('.help').die().live('click', function() {
         help($(this).attr('id'));

--- a/priv/www/js/tmpl/list-exchanges.ejs
+++ b/priv/www/js/tmpl/list-exchanges.ejs
@@ -1,0 +1,5 @@
+<select name="exchange">
+        <% for (var i = 0; i < exchanges.length; i++) { %>
+           <option value="<%= fmt_string(exchanges[i].name) %>"><%= fmt_exchange(exchanges[i].name) %></option>
+        <% } %>
+</select>

--- a/priv/www/js/tmpl/topic-permissions.ejs
+++ b/priv/www/js/tmpl/topic-permissions.ejs
@@ -29,8 +29,8 @@ for (var i = 0; i < topic_permissions.length; i++) {
              <td><%= link_vhost(permission.vhost) %></td>
 <% } %>
              <td><%= fmt_exchange(permission.exchange) %></td>
-             <td><%= fmt_string(permission.read) %></td>
              <td><%= fmt_string(permission.write) %></td>
+             <td><%= fmt_string(permission.read) %></td>
              <td class="c">
                <form action="#/topic-permissions" method="delete" class="confirm">
                  <input type="hidden" name="username" value="<%= fmt_string(permission.user) %>"/>

--- a/priv/www/js/tmpl/topic-permissions.ejs
+++ b/priv/www/js/tmpl/topic-permissions.ejs
@@ -1,0 +1,97 @@
+<div class="section">
+  <h2>Topic permissions</h2>
+  <div class="hider">
+    <h3>Current topic permissions</h3>
+    <% if (topic_permissions.length > 0) { %>
+    <table class="list">
+      <thead>
+        <tr>
+<% if (mode == 'vhost') { %>
+          <th>User</th>
+<% } else { %>
+          <th>Virtual host</th>
+<% } %>
+          <th>Exchange</th>
+          <th>Write regexp</th>
+          <th>Read regexp</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+<%
+for (var i = 0; i < topic_permissions.length; i++) {
+    var permission = topic_permissions[i];
+%>
+           <tr<%= alt_rows(i)%>>
+<% if (mode == 'vhost') { %>
+             <td><%= link_user(permission.user) %></td>
+<% } else { %>
+             <td><%= link_vhost(permission.vhost) %></td>
+<% } %>
+             <td><%= fmt_exchange(permission.exchange) %></td>
+             <td><%= fmt_string(permission.read) %></td>
+             <td><%= fmt_string(permission.write) %></td>
+             <td class="c">
+               <form action="#/topic-permissions" method="delete" class="confirm">
+                 <input type="hidden" name="username" value="<%= fmt_string(permission.user) %>"/>
+                 <input type="hidden" name="vhost" value="<%= fmt_string(permission.vhost) %>"/>
+                 <input type="hidden" name="exchange" value="<%= fmt_exchange_url(permission.exchange) %>"/>
+                 <input type="submit" value="Clear"/>
+               </form>
+             </td>
+           </tr>
+           <% } %>
+      </tbody>
+    </table>
+    <% } else { %>
+      <p>... no topic permissions ...</p>
+    <% } %>
+
+<h3>Set topic permission</h3>
+    <form action="#/topic-permissions" method="put">
+      <table class="form">
+        <tr>
+<% if (mode == 'vhost') { %>
+          <th>User</th>
+          <td>
+            <input type="hidden" name="vhost" value="<%= fmt_string(parent.name) %>"/>
+            <select name="username">
+              <% for (var i = 0; i < users.length; i++) { %>
+              <option value="<%= fmt_string(users[i].name) %>"><%= fmt_string(users[i].name) %></option>
+              <% } %>
+            </select>
+          </td>
+<% } else { %>
+          <th><label>Virtual Host:</label></th>
+          <td>
+            <input type="hidden" name="username" value="<%= fmt_string(parent.name) %>"/>
+            <select name="vhost" class="list-exchanges">
+              <% for (var i = 0; i < vhosts.length; i++) { %>
+              <option value="<%= fmt_string(vhosts[i].name) %>"><%= fmt_string(vhosts[i].name) %></option>
+              <% } %>
+            </select>
+          </td>
+<% } %>
+        </tr>
+        <tr>
+          <th><label>Exchange:</label></th>
+          <td>
+          <% console.log(exchanges) %>
+           <div id='list-exchanges'>
+            <%= format('list-exchanges', {'exchanges': exchanges}) %>
+           </div>
+          </td>
+        </tr>
+        <tr>
+          <th><label>Write regexp:</label></th>
+          <td><input type="text" name="write" value=".*"/></td>
+        </tr>
+        <tr>
+          <th><label>Read regexp:</label></th>
+          <td><input type="text" name="read" value=".*"/></td>
+        </tr>
+      </table>
+      <input type="submit" value="Set topic permission"/>
+    </form>
+  </div>
+</div>

--- a/priv/www/js/tmpl/user.ejs
+++ b/priv/www/js/tmpl/user.ejs
@@ -25,6 +25,8 @@
 
 <%= format('permissions', {'mode': 'user', 'permissions': permissions, 'vhosts': vhosts, 'parent': user}) %>
 
+<%= format('topic-permissions', {'mode': 'user', 'topic_permissions': topic_permissions, 'vhosts': vhosts, 'parent': user, 'exchanges': exchanges}) %>
+
 <div class="section-hidden">
   <h2>Update this user</h2>
   <div class="hider">

--- a/priv/www/js/tmpl/vhost.ejs
+++ b/priv/www/js/tmpl/vhost.ejs
@@ -27,6 +27,8 @@
 
 <%= format('permissions', {'mode': 'vhost', 'permissions': permissions, 'users': users, 'parent': vhost}) %>
 
+<%= format('topic-permissions', {'mode': 'vhost', 'topic_permissions': topic_permissions, 'users':users, 'parent': vhost, 'exchanges': exchanges}) %>
+
 <div class="section-hidden">
 <h2>Delete this vhost</h2>
 <div class="hider">

--- a/src/rabbit_mgmt_dispatcher.erl
+++ b/src/rabbit_mgmt_dispatcher.erl
@@ -132,6 +132,7 @@ dispatcher() ->
      {"/permissions/:vhost/:user",                             rabbit_mgmt_wm_permission, []},
      {"/topic-permissions",                                    rabbit_mgmt_wm_topic_permissions, []},
      {"/topic-permissions/:vhost/:user",                       rabbit_mgmt_wm_topic_permission, []},
+     {"/topic-permissions/:vhost/:user/:exchange",             rabbit_mgmt_wm_topic_permission, []},
      {"/aliveness-test/:vhost",                                rabbit_mgmt_wm_aliveness_test, []},
      {"/healthchecks/node",                                    rabbit_mgmt_wm_healthchecks, []},
      {"/healthchecks/node/:node",                              rabbit_mgmt_wm_healthchecks, []},

--- a/src/rabbit_mgmt_wm_topic_permission.erl
+++ b/src/rabbit_mgmt_wm_topic_permission.erl
@@ -74,7 +74,13 @@ accept_content(ReqData0, Context = #context{user = #user{username = Username}}) 
 delete_resource(ReqData, Context = #context{user = #user{username = Username}}) ->
     User = rabbit_mgmt_util:id(user, ReqData),
     VHost = rabbit_mgmt_util:id(vhost, ReqData),
-    rabbit_auth_backend_internal:clear_topic_permissions(User, VHost, Username),
+    case rabbit_mgmt_util:id(exchange, ReqData) of
+        none ->
+            rabbit_auth_backend_internal:clear_topic_permissions(User, VHost, Username);
+        Exchange ->
+            rabbit_auth_backend_internal:clear_topic_permissions(User, VHost, Exchange,
+                                                                 Username)
+    end,
     {true, ReqData, Context}.
 
 is_authorized(ReqData, Context) ->

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -526,14 +526,21 @@ topic_permissions_list_test(Config) ->
     http_put(Config, "/topic-permissions/myvhost2/myuser1", TopicPerms, {group, '2xx'}),
     http_put(Config, "/topic-permissions/myvhost1/myuser2", TopicPerms, {group, '2xx'}),
 
-    3 = length(http_get(Config, "/topic-permissions")),
-    2 = length(http_get(Config, "/users/myuser1/topic-permissions")),
+    TopicPerms2 = [{exchange, <<"amq.direct">>}, {write, <<"^a">>}, {read, <<"^b">>}],
+    http_put(Config, "/topic-permissions/myvhost1/myuser1", TopicPerms2, {group, '2xx'}),
+
+    4 = length(http_get(Config, "/topic-permissions")),
+    3 = length(http_get(Config, "/users/myuser1/topic-permissions")),
     1 = length(http_get(Config, "/users/myuser2/topic-permissions")),
-    2 = length(http_get(Config, "/vhosts/myvhost1/topic-permissions")),
+    3 = length(http_get(Config, "/vhosts/myvhost1/topic-permissions")),
     1 = length(http_get(Config, "/vhosts/myvhost2/topic-permissions")),
 
     http_get(Config, "/users/notmyuser/topic-permissions", ?NOT_FOUND),
     http_get(Config, "/vhosts/notmyvhost/topic-permissions", ?NOT_FOUND),
+
+    %% Delete permissions for a single vhost-user-exchange combination
+    http_delete(Config, "/topic-permissions/myvhost1/myuser1/amq.direct", {group, '2xx'}),
+    3 = length(http_get(Config, "/topic-permissions")),
 
     http_delete(Config, "/users/myuser1", {group, '2xx'}),
     http_delete(Config, "/users/myuser2", {group, '2xx'}),


### PR DESCRIPTION
Added endpoint /topic-permissions/:vhost/:user/:exchange to
delete individual permissions

Closes #405 