### PR TITLE
Use rabbit_mgmt_format:args_hash to get args hash in bindings API and tests

### DIFF
--- a/src/rabbit_mgmt_wm_binding.erl
+++ b/src/rabbit_mgmt_wm_binding.erl
@@ -115,7 +115,7 @@ lookup(RoutingKey, Hash, [#binding{args = Args} | Rest]) ->
     end.
 
 args_hash(Args) ->
-    list_to_binary(rabbit_misc:base64url(erlang:md5(term_to_binary(Args)))).
+    rabbit_mgmt_format:args_hash(Args).
 
 unquote(Name) ->
     list_to_binary(rabbit_http_util:unquote(Name)).

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -1348,7 +1348,7 @@ arguments_test(Config) ->
     passed.
 
 table_hash(Table) ->
-    rabbit_misc:base64url(erlang:md5(term_to_binary(Table))).
+    binary_to_list(rabbit_mgmt_format:args_hash(Table)).
 
 arguments_table_test(Config) ->
     Args = #{'upstreams' => [<<"amqp://localhost/%2f/upstream1">>,


### PR DESCRIPTION
Part of fix for rabbitmq/rabbitmq-server#1243

Requires https://github.com/rabbitmq/rabbitmq-management-agent/pull/47
