### PR TITLE
Extend resource augmentation optimisation.

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -340,10 +340,10 @@ augment_resources0(Resources, DefaultSort, BasicColumns, Pagination, ReqData,
         case {Pagination =/= undefined,
               column_strategy(Sort, BasicColumns),
               column_strategy(ColumnsAsStrings, BasicColumns)} of
-            {false, basic, basic} -> % no paging, no extended fields
+            {false, basic, basic} -> % no pagination, no extended fields
                 [SortFun];
             {false, _, _} ->
-                % no paging, extended columns means we need to augment all - SLOW
+                % no pagination, extended columns means we need to augment all - SLOW
                 [AugFun, SortFun];
             {true, basic, basic} ->
                 [SortFun, PageFun];

--- a/src/rabbit_mgmt_wm_exchanges.erl
+++ b/src/rabbit_mgmt_wm_exchanges.erl
@@ -54,8 +54,7 @@ to_json(ReqData, Context) ->
         Data = rabbit_mgmt_util:augment_resources(Basic, ?DEFAULT_SORT,
                                                   ?BASIC_COLUMNS, ReqData,
                                                   Context, fun augment/2),
-        rabbit_mgmt_util:reply(rabbit_mgmt_format:strip_pids(Data), ReqData,
-                               Context)
+        rabbit_mgmt_util:reply(Data, ReqData, Context)
     catch
         {error, invalid_range_parameters, Reason} ->
             rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)

--- a/src/rabbit_mgmt_wm_exchanges.erl
+++ b/src/rabbit_mgmt_wm_exchanges.erl
@@ -17,11 +17,16 @@
 -module(rabbit_mgmt_wm_exchanges).
 
 -export([init/3, rest_init/2, to_json/2, content_types_provided/2, is_authorized/2,
-         resource_exists/2, basic/1, augmented/2]).
+         resource_exists/2, basic/1]).
 -export([variances/2]).
 
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
+
+-define(DEFAULT_SORT, ["vhost", "name"]).
+
+-define(BASIC_COLUMNS, ["vhost", "name", "type", "durable", "auto_delete",
+                       "internal", "arguments", "pid"]).
 
 %%--------------------------------------------------------------------
 
@@ -44,8 +49,13 @@ resource_exists(ReqData, Context) ->
 
 to_json(ReqData, Context) ->
     try
-        rabbit_mgmt_util:reply_list_or_paginate(augmented(ReqData, Context),
-            ReqData, Context)
+        Basic = rabbit_mgmt_util:filter_vhost(basic(ReqData), ReqData,
+                                              Context),
+        Data = rabbit_mgmt_util:augment_resources(Basic, ?DEFAULT_SORT,
+                                                  ?BASIC_COLUMNS, ReqData,
+                                                  Context, fun augment/2),
+        rabbit_mgmt_util:reply(rabbit_mgmt_format:strip_pids(Data), ReqData,
+                               Context)
     catch
         {error, invalid_range_parameters, Reason} ->
             rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
@@ -56,10 +66,9 @@ is_authorized(ReqData, Context) ->
 
 %%--------------------------------------------------------------------
 
-augmented(ReqData, Context) ->
-    rabbit_mgmt_db:augment_exchanges(
-      rabbit_mgmt_util:filter_vhost(basic(ReqData), ReqData, Context),
-      rabbit_mgmt_util:range(ReqData), basic).
+augment(Basic, ReqData) ->
+    rabbit_mgmt_db:augment_exchanges(Basic, rabbit_mgmt_util:range(ReqData),
+                                     basic).
 
 basic(ReqData) ->
     [rabbit_mgmt_format:exchange(X) || X <- exchanges0(ReqData)].

--- a/src/rabbit_mgmt_wm_node_memory.erl
+++ b/src/rabbit_mgmt_wm_node_memory.erl
@@ -71,7 +71,7 @@ augment(Mode, ReqData) ->
 format(absolute, Result) ->
     Result;
 format(relative, Result) ->
-    {[{total, Total}], Rest} = lists:splitwith(fun({Key, _}) ->
+    {[{total, Total}], Rest} = lists:partition(fun({Key, _}) ->
                                                        Key == total
                                                end, Result),
     [{total, 100} | [{K, percentage(V, Total)} || {K, V} <- Rest]].

--- a/src/rabbit_mgmt_wm_queues.erl
+++ b/src/rabbit_mgmt_wm_queues.erl
@@ -53,8 +53,7 @@ to_json(ReqData, Context) ->
         Data = rabbit_mgmt_util:augment_resources(Basic, ?DEFAULT_SORT,
                                                   ?BASIC_COLUMNS, ReqData,
                                                   Context, fun augment/2),
-        rabbit_mgmt_util:reply(rabbit_mgmt_format:strip_pids(Data), ReqData,
-                               Context)
+        rabbit_mgmt_util:reply(Data, ReqData, Context)
     catch
         {error, invalid_range_parameters, Reason} ->
             rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData,

--- a/src/rabbit_mgmt_wm_queues.erl
+++ b/src/rabbit_mgmt_wm_queues.erl
@@ -17,11 +17,16 @@
 -module(rabbit_mgmt_wm_queues).
 
 -export([init/3, rest_init/2, to_json/2, content_types_provided/2, is_authorized/2,
-         resource_exists/2, basic/1, augmented/2]).
+         resource_exists/2, basic/1]).
 -export([variances/2]).
 
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
+
+-define(BASIC_COLUMNS, ["vhost", "name", "durable", "auto_delete", "exclusive",
+                       "owner_pid", "arguments", "pid", "state"]).
+
+-define(DEFAULT_SORT, ["vhost", "name"]).
 
 %%--------------------------------------------------------------------
 
@@ -44,16 +49,16 @@ resource_exists(ReqData, Context) ->
 
 to_json(ReqData, Context) ->
     try
-        rabbit_mgmt_util:unaugmented_reply_list_or_paginate(
-          basic_vhost_filtered(ReqData, Context),
-          fun is_sort_order_compatible_with_basic/1,
-          fun (Items) ->
-                  rabbit_mgmt_format:strip_pids(augment(Items, ReqData))
-          end,
-          ReqData, Context)
+        Basic = basic_vhost_filtered(ReqData, Context),
+        Data = rabbit_mgmt_util:augment_resources(Basic, ?DEFAULT_SORT,
+                                                  ?BASIC_COLUMNS, ReqData,
+                                                  Context, fun augment/2),
+        rabbit_mgmt_util:reply(rabbit_mgmt_format:strip_pids(Data), ReqData,
+                               Context)
     catch
         {error, invalid_range_parameters, Reason} ->
-            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData,
+                                         Context)
     end.
 
 is_authorized(ReqData, Context) ->
@@ -67,20 +72,12 @@ basic(ReqData) ->
         [rabbit_mgmt_format:queue(Q#amqqueue{state = down}) ||
             Q <- down_queues(ReqData)].
 
-augmented(ReqData, Context) ->
-    augment(rabbit_mgmt_util:filter_vhost(basic(ReqData), ReqData, Context), ReqData).
-
 %%--------------------------------------------------------------------
 %% Private helpers
 
-is_sort_order_compatible_with_basic(MentionedSortColumns) ->
-    SafeColumns = ["vhost", "name", "durable", "auto_delete", "exclusive",
-                   "owner_pid", "arguments", "pid", "state"],
-    SafeColumnsSet = sets:from_list(SafeColumns),
-    sets:is_subset(sets:from_list(MentionedSortColumns), SafeColumnsSet).
-
 augment(Basic, ReqData) ->
-    rabbit_mgmt_db:augment_queues(Basic, rabbit_mgmt_util:range_ceil(ReqData), basic).
+    rabbit_mgmt_db:augment_queues(Basic, rabbit_mgmt_util:range_ceil(ReqData),
+                                  basic).
 
 basic_vhost_filtered(ReqData, Context) ->
     rabbit_mgmt_util:filter_vhost(basic(ReqData), ReqData, Context).

--- a/src/rabbit_mgmt_wm_vhosts.erl
+++ b/src/rabbit_mgmt_wm_vhosts.erl
@@ -18,10 +18,14 @@
 
 -export([init/3, rest_init/2, to_json/2, content_types_provided/2, is_authorized/2]).
 -export([variances/2]).
--export([basic/0, augmented/2]).
+-export([basic/0]).
 
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
+
+-define(BASIC_COLUMNS, ["name", "tracing", "pid"]).
+
+-define(DEFAULT_SORT, ["name"]).
 
 %%--------------------------------------------------------------------
 
@@ -36,10 +40,15 @@ variances(Req, Context) ->
 content_types_provided(ReqData, Context) ->
    {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
 
-to_json(ReqData, Context) ->
+to_json(ReqData, Context = #context{user = User}) ->
     try
-        rabbit_mgmt_util:reply_list_or_paginate(
-          augmented(ReqData, Context),ReqData, Context)
+        Basic = [rabbit_vhost:info(V)
+                 || V <- rabbit_mgmt_util:list_visible_vhosts(User)],
+        Data = rabbit_mgmt_util:augment_resources(Basic, ?DEFAULT_SORT,
+                                                  ?BASIC_COLUMNS, ReqData,
+                                                  Context, fun augment/2),
+        rabbit_mgmt_util:reply(rabbit_mgmt_format:strip_pids(Data), ReqData,
+                               Context)
     catch
         {error, invalid_range_parameters, Reason} ->
             rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
@@ -50,10 +59,8 @@ is_authorized(ReqData, Context) ->
 
 %%--------------------------------------------------------------------
 
-augmented(ReqData, #context{user = User}) ->
-    rabbit_mgmt_db:augment_vhosts(
-      [rabbit_vhost:info(V) || V <- rabbit_mgmt_util:list_visible_vhosts(User)],
-      rabbit_mgmt_util:range(ReqData)).
+augment(Basic, ReqData) ->
+    rabbit_mgmt_db:augment_vhosts(Basic, rabbit_mgmt_util:range(ReqData)).
 
 basic() ->
     rabbit_vhost:info_all([name]).

--- a/src/rabbit_mgmt_wm_vhosts.erl
+++ b/src/rabbit_mgmt_wm_vhosts.erl
@@ -47,8 +47,7 @@ to_json(ReqData, Context = #context{user = User}) ->
         Data = rabbit_mgmt_util:augment_resources(Basic, ?DEFAULT_SORT,
                                                   ?BASIC_COLUMNS, ReqData,
                                                   Context, fun augment/2),
-        rabbit_mgmt_util:reply(rabbit_mgmt_format:strip_pids(Data), ReqData,
-                               Context)
+        rabbit_mgmt_util:reply(Data, ReqData, Context)
     catch
         {error, invalid_range_parameters, Reason} ->
             rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)


### PR DESCRIPTION
Analyses the http request paging, column and sorting parameters and builds
up the most optimal augmentation pipeline. This allows us to skip
cluster-wide augmentation when only basic fields are requested as well
as reduce the augmentation set in certains scenarios prior to
augmentation.

`hop` and `rabbit-hole` tests suites pass.

Fixes #417 