### PR TITLE
DO NOT MERGE Filter by columns and page

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -242,7 +242,7 @@ get_value_param(Name, ReqData) ->
 reply_list(Facts, DefaultSorts, ReqData, Context, Pagination) ->
     SortList =
     sort_list_and_paginate(
-          extract_columns_list(Facts, ReqData),
+          extract_columns_list(Facts, ReqData, false),
           DefaultSorts,
           get_value_param(<<"sort">>, ReqData),
           get_sort_reverse(ReqData), Pagination),
@@ -290,6 +290,7 @@ maybe_augment_paged_facts(ShouldAugment, AugmentFn, PagingResult) ->
       end,
      PagingResult).
 
+
 %% Augmenting items with calculated stats (with the help of exometer)
 %% is quite expensive, so when request is paged and sort order doesn't
 %% reference augmented columns, we can postpone augmentation until the
@@ -319,7 +320,7 @@ unaugmented_reply_list_or_paginate(BasicFacts,
               AugmentAfterPagination = is_pagination_requested(Pagination) andalso CanAugmentAfterPaginationPredicate(MentionedSortColumns),
               FactsForPagination = maybe_augment_facts(not AugmentAfterPagination, AugmentFn, BasicFacts),
               SortedFacts = sort_list(
-                              extract_columns_list(FactsForPagination, ReqData),
+                              extract_columns_list(FactsForPagination, ReqData, true),
                               DefaultSorts,
                               SortParam,
                               get_sort_reverse(ReqData)),
@@ -536,9 +537,18 @@ extract_columns(Item, ReqData) ->
     maybe_pagination(Item, is_pagination_requested(pagination_params(ReqData)),
 		     ReqData).
 
-extract_columns_list(Items, ReqData) ->
+
+maybe_column_pid(all, _) -> all;
+maybe_column_pid(Cols, true) ->
+    case lists:member([<<"pid">>], Cols) of
+	true -> Cols;
+	false -> [[<<"pid">>] | Cols]
+    end;
+maybe_column_pid(Cols, false) -> Cols.
+
+extract_columns_list(Items, ReqData, CheckPid) ->
     Cols = columns(ReqData),
-    [extract_column_items(Item, Cols) || Item <- Items].
+    [extract_column_items(Item, maybe_column_pid(Cols, CheckPid)) || Item <- Items].
 
 columns(ReqData) ->
     case cowboy_req:qs_val(<<"columns">>, ReqData) of

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -97,6 +97,7 @@ groups() ->
                                exchanges_pagination_test,
                                exchanges_pagination_permissions_test,
                                queue_pagination_test,
+                               queue_pagination_columns_test,
                                queues_pagination_permissions_test,
                                samples_range_test,
                                sorting_test,
@@ -1556,6 +1557,58 @@ queue_pagination_test(Config) ->
     http_delete(Config, "/queues/vh1/test1", ?NO_CONTENT),
     http_delete(Config, "/queues/%2f/test2_reg", ?NO_CONTENT),
     http_delete(Config, "/queues/vh1/reg_test3", ?NO_CONTENT),
+    http_delete(Config, "/vhosts/vh1", ?NO_CONTENT),
+    passed.
+
+queue_pagination_columns_test(Config) ->
+    QArgs = [],
+    PermArgs = [{configure, <<".*">>}, {write, <<".*">>}, {read, <<".*">>}],
+    http_put(Config, "/vhosts/vh1", none, [?CREATED, ?NO_CONTENT]),
+    http_put(Config, "/permissions/vh1/guest", PermArgs, [?CREATED, ?NO_CONTENT]),
+
+    http_get(Config, "/queues/vh1?columns=name&page=1&page_size=2", ?OK),
+    http_put(Config, "/queues/%2f/queue_a", QArgs, [?CREATED, ?NO_CONTENT]),
+    http_put(Config, "/queues/vh1/queue_b", QArgs, [?CREATED, ?NO_CONTENT]),
+    http_put(Config, "/queues/%2f/queue_c", QArgs, [?CREATED, ?NO_CONTENT]),
+    http_put(Config, "/queues/vh1/queue_d", QArgs, [?CREATED, ?NO_CONTENT]),
+    PageOfTwo = http_get(Config, "/queues?columns=name&page=1&page_size=2", ?OK),
+    ?assertEqual(4, proplists:get_value(total_count, PageOfTwo)),
+    ?assertEqual(4, proplists:get_value(filtered_count, PageOfTwo)),
+    ?assertEqual(2, proplists:get_value(item_count, PageOfTwo)),
+    ?assertEqual(1, proplists:get_value(page, PageOfTwo)),
+    ?assertEqual(2, proplists:get_value(page_size, PageOfTwo)),
+    ?assertEqual(2, proplists:get_value(page_count, PageOfTwo)),
+    assert_list([[{name, <<"queue_a">>}],
+        [{name, <<"queue_b">>}]
+    ], proplists:get_value(items, PageOfTwo)),
+
+    ColumnNameVhost = http_get(Config, "/queues/vh1?columns=name&page=1&page_size=2", ?OK),
+    ?assertEqual(2, proplists:get_value(total_count, ColumnNameVhost)),
+    ?assertEqual(2, proplists:get_value(filtered_count, ColumnNameVhost)),
+    ?assertEqual(2, proplists:get_value(item_count, ColumnNameVhost)),
+    ?assertEqual(1, proplists:get_value(page, ColumnNameVhost)),
+    ?assertEqual(2, proplists:get_value(page_size, ColumnNameVhost)),
+    ?assertEqual(1, proplists:get_value(page_count, ColumnNameVhost)),
+    assert_list([[{name, <<"queue_b">>}],
+        [{name, <<"queue_d">>}]
+    ], proplists:get_value(items, ColumnNameVhost)),
+
+    ColumnsNameVhost = http_get(Config, "/queues?columns=name,vhost&page=2&page_size=2", ?OK),
+    ?assertEqual(4, proplists:get_value(total_count, ColumnsNameVhost)),
+    ?assertEqual(4, proplists:get_value(filtered_count, ColumnsNameVhost)),
+    ?assertEqual(2, proplists:get_value(item_count, ColumnsNameVhost)),
+    ?assertEqual(2, proplists:get_value(page, ColumnsNameVhost)),
+    ?assertEqual(2, proplists:get_value(page_size, ColumnsNameVhost)),
+    ?assertEqual(2, proplists:get_value(page_count, ColumnsNameVhost)),
+    assert_list([[{name, <<"queue_b">>},{vhost, <<"vh1">>}],
+        [{name, <<"queue_d">>},{vhost, <<"vh1">>}]
+    ], proplists:get_value(items, ColumnsNameVhost)),
+
+
+    http_delete(Config, "/queues/%2f/queue_a", ?NO_CONTENT),
+    http_delete(Config, "/queues/vh1/queue_b", ?NO_CONTENT),
+    http_delete(Config, "/queues/%2f/queue_c", ?NO_CONTENT),
+    http_delete(Config, "/queues/vh1/queue_d", ?NO_CONTENT),
     http_delete(Config, "/vhosts/vh1", ?NO_CONTENT),
     passed.
 


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-management/issues/404

**Note** the `stable` version introduces a [new bug](https://github.com/rabbitmq/rabbitmq-management/issues/404#issuecomment-308375157), fixed [here](https://github.com/rabbitmq/rabbitmq-management/blob/rabbitmq-management-404/src/rabbit_mgmt_util.erl#L541). 

To test manually:
```
curl -X GET -u guest:guest http://localhost:15672/api/queues\?columns\=name\&page\=1
```
or
```
curl -X GET -u guest:guest http://localhost:15672/api/queues\?columns\=name,vhost\&page\=1\&page_size\=2
```



 