### PR TITLE
Fix rabbitmqadmin link on /cli page. Make its URI absolute so it alwa…

### DIFF
--- a/priv/www/cli/index.html
+++ b/priv/www/cli/index.html
@@ -11,7 +11,7 @@
     <h1>rabbitmqadmin</h1>
 
     <p>
-      Download it from <a href="rabbitmqadmin">here</a> (Right click,
+      Download it from <a href="/cli/rabbitmqadmin">here</a> (Right click,
       Save as), make executable, and drop it in your path. Note that
       many browsers will rename the
       file <code>rabbitmqadmin.txt</code>. You will need Python


### PR DESCRIPTION
…ys works, even when /cli page gets accessed without trailing slash, like http://rabbitmq.server:15672/cli