### PR TITLE
Fix usage of parseInt()

### DIFF
--- a/priv/www/js/dispatcher.js
+++ b/priv/www/js/dispatcher.js
@@ -272,8 +272,18 @@ dispatcher_add(function(sammy) {
                       'vhosts': '/vhosts'}, 'limits');
 
     sammy.put('#/limits', function() {
-        this.params.value = parseInt(this.params.value) || this.params.value;
-        if (sync_put(this, '/vhost-limits/:vhost/:name')) update();
+        var valAsInt = parseInt(this.params.value);
+        if (isNaN(valAsInt)) {
+            var e = 'Validation failed\n\n' +
+                this.params.name + ' should be a number, actually was "' +
+                this.params.value + '"';
+            show_popup('warn', fmt_escape_html(e));
+        } else {
+            this.params.value = valAsInt;
+            if (sync_put(this, '/vhost-limits/:vhost/:name')) {
+                update();
+            }
+        }
     });
     sammy.del('#/limits', function() {
         if (sync_delete(this, '/vhost-limits/:vhost/:name')) update();


### PR DESCRIPTION
Prior to this change, entering a value of "0" was correctly parsed to 0, which is falsy,
which meant that the second clause of the OR statement was executed, sending the string "0"
to the server.

Found while testing #421 

rabbitmq/rabbitmq-server#1288 also goes along with this.