### PR TITLE
Allow users w/o password or password hash to be created

### DIFF
--- a/src/rabbit_mgmt_wm_user.erl
+++ b/src/rabbit_mgmt_wm_user.erl
@@ -115,7 +115,8 @@ put_user(User, Version) ->
             {true, false} ->
                 rabbit_credential_validation:validate(Username, Password) =:= ok;
             {false, true} -> true;
-            _             -> false
+            _             ->
+                rabbit_credential_validation:validate(Username, Password) =:= ok
         end,
 
     case UserExists of
@@ -140,7 +141,12 @@ put_user(User, Version) ->
                 {true, true}   ->
                     throw({error, both_password_and_password_hash_are_provided});
                 {false, false} ->
-                    throw({error, no_password_or_password_hash_provided})
+                    %% this user won't be able to sign in using
+                    %% a username/password pair but can be used for x509 certificate authentication,
+                    %% with authn backends such as HTTP or LDAP and so on.
+                    io:format("PassedCredentialValidation: ~p, Username: ~p, Tags: ~p",
+                              [PassedCredentialValidation, Username, Tags]),
+                    create_user_with_password(PassedCredentialValidation, Username, <<"">>, Tags)
             end
     end.
 

--- a/src/rabbit_mgmt_wm_user.erl
+++ b/src/rabbit_mgmt_wm_user.erl
@@ -144,8 +144,6 @@ put_user(User, Version) ->
                     %% this user won't be able to sign in using
                     %% a username/password pair but can be used for x509 certificate authentication,
                     %% with authn backends such as HTTP or LDAP and so on.
-                    io:format("PassedCredentialValidation: ~p, Username: ~p, Tags: ~p",
-                              [PassedCredentialValidation, Username, Tags]),
                     create_user_with_password(PassedCredentialValidation, Username, <<"">>, Tags)
             end
     end.

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -58,7 +58,7 @@ groups() ->
                                vhosts_trace_test,
                                users_test,
                                users_legacy_administrator_test,
-                               adding_a_user_without_password_or_hash_fails_test,
+                               adding_a_user_without_password_or_hash_test,
                                adding_a_user_with_both_password_and_hash_fails_test,
                                updating_a_user_without_password_or_hash_clears_password_test,
                                user_credential_validation_accept_everything_succeeds_test,
@@ -377,9 +377,12 @@ users_legacy_administrator_test(Config) ->
     http_delete(Config, "/users/myuser2", ?NO_CONTENT),
     passed.
 
-adding_a_user_without_password_or_hash_fails_test(Config) ->
-    http_put(Config, "/users/myuser", [{flim, <<"flam">>}],       ?BAD_REQUEST),
-    http_put(Config, "/users/myuser", [{tags, <<"management">>}], ?BAD_REQUEST).
+%% creating a passwordless user makes sense when x509x certificates or another
+%% "external" authentication mechanism or backend is used.
+%% See rabbitmq/rabbitmq-management#383.
+adding_a_user_without_password_or_hash_test(Config) ->
+    http_put(Config, "/users/myuser", [{tags, <<"management">>}], [?CREATED, ?NO_CONTENT]),
+    http_put(Config, "/users/myuser", [{tags, <<"management">>}], [?CREATED, ?NO_CONTENT]).
 
 adding_a_user_with_both_password_and_hash_fails_test(Config) ->
     http_put(Config, "/users/myuser", [{password,      <<"password">>},
@@ -392,8 +395,8 @@ adding_a_user_with_both_password_and_hash_fails_test(Config) ->
 updating_a_user_without_password_or_hash_clears_password_test(Config) ->
     http_put(Config, "/users/myuser", [{tags,     <<"management">>},
                                        {password, <<"myuser">>}], [?CREATED, ?NO_CONTENT]),
-    %% in this case providing no password or password_hash is valid:
-    %% it clears credentials
+    %% in this case providing no password or password_hash will
+    %% clear users' credentials
     http_put(Config, "/users/myuser", [{tags,     <<"management">>}], [?CREATED, ?NO_CONTENT]),
     assert_item([{name, <<"myuser">>}, {tags, <<"management">>},
                                        {password_hash, <<>>},


### PR DESCRIPTION
 * This is a valid case for environments where external
   authn mechanisms (x509 certificates) or backends (e.g. HTTP) are used.
 * We already allow this for existing users.

Closes #383.