### PR TITLE
Revert "rabbit_mgmt_http_SUITE: Comment out test on memory breakdow values"

### DIFF
--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -224,13 +224,7 @@ memory_test(Config) ->
     Breakdown = pget(memory, Result1),
     assert_keys(Keys, Breakdown),
     assert_item([{total, 100}], Breakdown),
-    %% FIXME: Since commit 0872a15a050176ab7598bc3d1b21a2d5c5af3052
-    %% in rabbitmq-server, `total` has no relationship with the other
-    %% counters: total is the resident memory footprint of the OS
-    %% process (so pages in physical memory), but the other counters are
-    %% based on what was actually allocated. Those counters should be
-    %% compared to the total reported by erlang:memory() instead.
-    %assert_percentage(Breakdown),
+    assert_percentage(Breakdown),
     http_get(Config, "/nodes/nonode/memory/relative", ?NOT_FOUND),
     passed.
 


### PR DESCRIPTION
Requires rabbitmq/rabbitmq-server#1295
This reverts commit 4af7b63dbed5577ee5c2be0cb86c911ba0662490.
The assertion can be uncommented because the bug has been fixed.
[related to rabbitmq/rabbitmq-server#1294]
[#149066379]