### PR TITLE
rabbitmqadmin: add --base-uri

### DIFF
--- a/bin/rabbitmqadmin
+++ b/bin/rabbitmqadmin
@@ -295,7 +295,7 @@ def make_parser():
         help="connect to port PORT",
         metavar="PORT")
     add("--path-prefix", dest="path_prefix",
-        help="use specific URI path prefix for the RabbitMQ HTTP API (default: blank string)")
+        help="use specific URI path prefix for the RabbitMQ HTTP API. /api and operation path will be appended to it. (default: blank string)")
     add("-V", "--vhost", dest="vhost",
         help="connect to vhost VHOST [default: all vhosts for list, '/' for declare]",
         metavar="VHOST")
@@ -305,6 +305,9 @@ def make_parser():
     add("-p", "--password", dest="password",
         help="connect using password PASSWORD",
         metavar="PASSWORD")
+    add("-U", "--base-uri", dest="base_uri",
+        help="connect using a base HTTP API URI. /api and operation path will be appended to it. Path will be ignored. --vhost has to be provided separately.",
+        metavar="URI")
     add("-q", "--quiet", action="store_false", dest="verbose",
         help="suppress status messages")
     add("-s", "--ssl", action="store_true", dest="ssl",
@@ -380,6 +383,16 @@ def make_configuration():
                     setattr(options, key, val == "True")
                 else:
                     setattr(options, key, val)
+
+    # if --base-uri is passed, set connection parameters from it
+    if options.base_uri is not None:
+        u = urlparse.urlparse(options.base_uri)
+        for key in ["hostname", "port", "username", "password"]:
+            if getattr(u, key) is not None:
+                setattr(options, key, getattr(u, key))
+
+        if u.path is not None and (u.path != "") and (u.path != "/"):
+            print("WARN: path in --base-uri is ignored. Please specify --vhost and/or --path-prefix separately.\n")
 
     return (options, args)
 

--- a/test/rabbit_mgmt_rabbitmqadmin_SUITE.erl
+++ b/test/rabbit_mgmt_rabbitmqadmin_SUITE.erl
@@ -27,6 +27,7 @@ groups() ->
     Tests = [
              help,
              host,
+             base_uri,
              config,
              user,
              fmt_long,
@@ -112,6 +113,17 @@ host(Config) ->
     {ok, _} = run(Config, ["--host", "localhost", "show", "overview"]),
     {error, _, _} = run(Config, ["--host", "some-host-that-does-not-exist",
                                  "show", "overview"]).
+
+base_uri(Config) ->
+    {ok, _} = run(Config, ["--base-uri", "http://localhost:15672",  "list", "exchanges"]),
+    {ok, _} = run(Config, ["--base-uri", "http://localhost:15672/", "list", "exchanges"]),
+    {ok, _} = run(Config, ["--base-uri", "http://localhost:15672",  "--vhost", "/", "list", "exchanges"]),
+    {ok, _} = run(Config, ["--base-uri", "http://localhost:15672/", "--vhost", "/", "list", "exchanges"]),
+    {error, _, _} = run(Config, ["--base-uri", "http://some-host-that-does-not-exist:15672/",
+                                 "list", "exchanges"]),
+    {error, _, _} = run(Config, ["--base-uri", "http://localhost:15672/", "--vhost", "some-vhost-that-does-not-exist",
+                                 "list", "exchanges"]).
+
 
 config(Config) ->
     PrivDir = ?config(priv_dir, Config),


### PR DESCRIPTION
When specified, hostname, port, username and password
are taken from the URI. URI path is intentionally ignored
because AMQP(S) URIs use path to configure target virtual host
but HTTP APIs typically use URI paths to specify an endpoint
prefix (--path-prefix in rabbitmqadmin).

To avoid confusion we log a warning and ask the user to
specify --vhost and/or --path-prefix explicitly.

Closes #437.