### PR TITLE
Add SIGPIPE handling

### DIFF
--- a/bin/rabbitmqadmin
+++ b/bin/rabbitmqadmin
@@ -14,6 +14,8 @@
 #
 #   The Initial Developer of the Original Code is GoPivotal, Inc.
 #   Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+from signal import signal, SIGPIPE, SIG_DFL
+signal(SIGPIPE, SIG_DFL)
 
 import sys
 if sys.version_info[0] < 2 or (sys.version_info[0] == 2 and sys.version_info[1] < 6):

--- a/bin/rabbitmqadmin
+++ b/bin/rabbitmqadmin
@@ -14,8 +14,11 @@
 #
 #   The Initial Developer of the Original Code is GoPivotal, Inc.
 #   Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
-from signal import signal, SIGPIPE, SIG_DFL
-signal(SIGPIPE, SIG_DFL)
+try:
+    from signal import signal, SIGPIPE, SIG_DFL
+    signal(SIGPIPE, SIG_DFL)
+except ImportError:
+    pass
 
 import sys
 if sys.version_info[0] < 2 or (sys.version_info[0] == 2 and sys.version_info[1] < 6):


### PR DESCRIPTION
When piping the output of a Python program, it is possible that SIGPIPE will be raised
and the interpreter will throw an exception. More information here:

http://newbebweb.blogspot.com/2012/02/python-head-ioerror-errno-32-broken.html

The following code reproduces the issue:

```python
# from signal import signal, SIGPIPE, SIG_DFL 
# signal(SIGPIPE, SIG_DFL)

for x in range(10000):
    print(x)
```

Run as `python ./repro.py | head` and you'll see the exception. Un-commenting the first two lines fixes it.

Testing now on Windows.

Fixes #438