### PR TITLE
Give vhost access to the user creating it

### DIFF
--- a/src/rabbit_mgmt_wm_vhost.erl
+++ b/src/rabbit_mgmt_wm_vhost.erl
@@ -91,7 +91,9 @@ id(ReqData) ->
 put_vhost(Name, Trace, Username) ->
     case rabbit_vhost:exists(Name) of
         true  -> ok;
-        false -> rabbit_vhost:add(Name, Username)
+        false -> rabbit_vhost:add(Name, Username),
+                 rabbit_auth_backend_internal:set_permissions(
+                   Username, Name, <<".*">>, <<".*">>, <<".*">>, Username)
     end,
     case Trace of
         true      -> rabbit_trace:start(Name);

--- a/test/rabbit_mgmt_rabbitmqadmin_SUITE.erl
+++ b/test/rabbit_mgmt_rabbitmqadmin_SUITE.erl
@@ -202,14 +202,15 @@ users(Config) ->
 permissions(Config) ->
     {ok, _} = run(Config, ["declare", "vhost", "name=foo"]),
     {ok, _} = run(Config, ["declare", "user", "name=bar", "password=pass", "tags="]),
-    {ok, [["guest", "/"]]} = run_table(Config, ["list", "permissions",
-                                                "user", "vhost"]),
+    %% The user that creates the vhosts gets permission automatically
+    %% See https://github.com/rabbitmq/rabbitmq-management/issues/444
+    {ok, [["guest", "/"],
+          ["guest", "foo"]]} = run_table(Config, ["list", "permissions",
+                                                  "user", "vhost"]),
     {ok, _} = run(Config, ["declare", "permission", "user=bar", "vhost=foo",
                            "configure=.*", "write=.*", "read=.*"]),
-    {ok, [["guest", "/"], ["bar", "foo"]]} =  run_table(Config, ["list",
-                                                                 "permissions",
-                                                                 "user",
-                                                                 "vhost"]),
+    {ok, [["guest", "/"], ["bar", "foo"], ["guest", "foo"]]}
+     =  run_table(Config, ["list", "permissions", "user", "vhost"]),
     {ok, _} = run(Config, ["delete", "user", "name=bar"]),
     {ok, _} = run(Config, ["delete", "vhost", "name=foo"]).
 


### PR DESCRIPTION
This allows the admin user that creates the vhost to access immediately to all access-controlled by vhost pages. This is a usability improvement first and foremost.

We assume that if a user has the permissions to create vhosts, nothing stops them from granting themselves any permissions so there is no practical impact on security or privacy.

Closes #444 