### PR TITLE
Change users bulk delete to use a deletion resource.

### DIFF
--- a/src/rabbit_mgmt_dispatcher.erl
+++ b/src/rabbit_mgmt_dispatcher.erl
@@ -124,6 +124,7 @@ dispatcher() ->
      %% /channels/:channel is already taken, we cannot use our standard scheme here
      {"/vhosts/:vhost/channels",                               rabbit_mgmt_wm_channels_vhost, []},
      {"/users",                                                rabbit_mgmt_wm_users, []},
+     {"/users/bulk-delete",                                    rabbit_mgmt_wm_users_bulk_delete, []},
      {"/users/:user",                                          rabbit_mgmt_wm_user, []},
      {"/users/:user/permissions",                              rabbit_mgmt_wm_permissions_user, []},
      {"/users/:user/topic-permissions",                        rabbit_mgmt_wm_topic_permissions_user, []},

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -29,7 +29,8 @@
                                 http_get_no_map/2,
                                 http_put/4, http_put/6,
                                 http_post/4, http_post/6,
-                                http_delete/3, http_delete/4, http_delete/5,
+                                http_upload_raw/8,
+                                http_delete/3, http_delete/5,
                                 http_put_raw/4, http_post_accept_json/4,
                                 req/4, auth_header/2,
                                 amqp_port/1]).
@@ -397,11 +398,14 @@ users_bulk_delete_test(Config) ->
     http_get(Config, "/users/myuser1", {group, '2xx'}),
     http_get(Config, "/users/myuser2", {group, '2xx'}),
     http_get(Config, "/users/myuser3", {group, '2xx'}),
-    http_delete(Config, "/users", {group, '2xx'}, "{\"users\": [\"myuser1\", \"myuser2\"]}"),
+
+    http_post_json(Config, "/users/bulk-delete",
+                   "{\"users\": [\"myuser1\", \"myuser2\"]}", {group, '2xx'}),
     http_get(Config, "/users/myuser1", ?NOT_FOUND),
     http_get(Config, "/users/myuser2", ?NOT_FOUND),
     http_get(Config, "/users/myuser3", {group, '2xx'}),
-    http_delete(Config, "/users", {group, '2xx'}, "{\"users\": [\"myuser3\"]}"),
+    http_post_json(Config, "/users/bulk-delete", "{\"users\": [\"myuser3\"]}",
+                    {group, '2xx'}),
     http_get(Config, "/users/myuser3", ?NOT_FOUND),
     passed.
 
@@ -2637,3 +2641,8 @@ wait_until(Fun, N) ->
         timer:sleep(?COLLECT_INTERVAL),
         wait_until(Fun, N - 1)
     end.
+
+http_post_json(Config, Path, Body, Assertion) ->
+    http_upload_raw(Config,  post, Path, Body, "guest", "guest",
+                    Assertion, [{"Content-Type", "application/json"}]).
+


### PR DESCRIPTION
DELETE with a payload doesn't have prescribed semantics and at least
older version of the HTTP spec prescribe that the request uri should
full identify the resource to be deleted.

This change introduces a /users/bulk-delete resource to which we POST the
users that are to be deleted.

[#149484991]