### PR TITLE
Make sure GET /api/consumers formats consumer arguments

### DIFF
--- a/src/rabbit_mgmt_wm_consumers.erl
+++ b/src/rabbit_mgmt_wm_consumers.erl
@@ -50,10 +50,10 @@ to_json(ReqData, Context = #context{user = User}) ->
               VHost -> VHost
           end,
 
-    Consumers = rabbit_mgmt_format:strip_pids(
-                          rabbit_mgmt_db:get_all_consumers(Arg)),
+    Consumers = rabbit_mgmt_format:strip_pids(rabbit_mgmt_db:get_all_consumers(Arg)),
+    Formatted = [rabbit_mgmt_format:format_consumer_arguments(C) || C <- Consumers],
     rabbit_mgmt_util:reply_list(
-      filter_user(Consumers, User), ReqData, Context).
+      filter_user(Formatted, User), ReqData, Context).
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized(ReqData, Context).


### PR DESCRIPTION
Besides #424 this makes sure consumer argument
JSON serialisation doesn't fail for that endpoint in general.

Depends on https://github.com/rabbitmq/rabbitmq-management-agent/commit/371322d0a42dead095edf97d3204822f6aad005a, which was pushed
to `stable` earlier during an investigation of consumer argument serialisation crashes.

How to test it:

 * Start a node
 * In a client REPL (Bunny, Pika, …), open a connection, a channel, declare a queue and add a consumer
 * Add another consumer with non-empty arguments, e.g. `{"x-priority" => 5}`
 * `curl -u guest:guest -X GET http://127.0.0.1:15672/api/consumers | python -m json.tool`
 * There should be no handler crashes in the log
 * Ensure that `arguments` is a JSON object instead of an array

Fixes #424.