### PR TITLE
Change the vhost API to have cluster_state instead of state.

### DIFF
--- a/priv/www/js/formatters.js
+++ b/priv/www/js/formatters.js
@@ -933,7 +933,7 @@ function fmt_vhost_state(vhost){
     var non_ok_count = 0;
     for(var node in cluster_state){
         var node_state = cluster_state[node];
-        if(cluster_state[node] == "down" || cluster_state[node] == "nodedown"){
+        if(cluster_state[node] == "stopped" || cluster_state[node] == "nodedown"){
             non_ok_count++;
             down_nodes.push(node);
         } else if(cluster_state[node] == "running"){
@@ -943,9 +943,9 @@ function fmt_vhost_state(vhost){
     if(non_ok_count == 0 ){
         return fmt_state('green', 'running', '');
     } else if(non_ok_count > 0 && ok_count == 0){
-        return fmt_state('red', 'down', 'Vhost supervisor is not running.');
+        return fmt_state('red', 'stopped', 'Vhost supervisor is not running.');
     } else if(non_ok_count > 0 && ok_count > 0){
-        return fmt_state('yellow', 'partial', 'Vhost supervisor is down on some cluster nodes: ' + down_nodes.join(', '));
+        return fmt_state('yellow', 'partial', 'Vhost supervisor is stopped on some cluster nodes: ' + down_nodes.join(', '));
     }
 }
 

--- a/priv/www/js/formatters.js
+++ b/priv/www/js/formatters.js
@@ -926,6 +926,29 @@ function fmt_regex_request(template, defaultName){
     return result;
 }
 
+function fmt_vhost_state(vhost){
+    var cluster_state = vhost.cluster_state;
+    var down_nodes = [];
+    var ok_count = 0;
+    var non_ok_count = 0;
+    for(var node in cluster_state){
+        var node_state = cluster_state[node];
+        if(cluster_state[node] == "down" || cluster_state[node] == "nodedown"){
+            non_ok_count++;
+            down_nodes.push(node);
+        } else if(cluster_state[node] == "running"){
+            ok_count++;
+        }
+    }
+    if(non_ok_count == 0 ){
+        return fmt_state('green', 'running', '');
+    } else if(non_ok_count > 0 && ok_count == 0){
+        return fmt_state('red', 'down', 'Vhost supervisor is not running.');
+    } else if(non_ok_count > 0 && ok_count > 0){
+        return fmt_state('yellow', 'partial', 'Vhost supervisor is down on some cluster nodes: ' + down_nodes.join(', '));
+    }
+}
+
 function isNumberKey(evt){
     var charCode = (evt.which) ? evt.which : event.keyCode
     if (charCode > 31 && (charCode < 48 || charCode > 57))

--- a/priv/www/js/global.js
+++ b/priv/www/js/global.js
@@ -115,7 +115,8 @@ var COLUMNS =
                   ['connected_at', 'Connected at', false]]},
 
      'vhosts':
-     {'Messages': [['msgs-ready',      'Ready',          true],
+     {'Overview': [['cluster-state',   'Cluster state',  false]],
+      'Messages': [['msgs-ready',      'Ready',          true],
                    ['msgs-unacked',    'Unacknowledged', true],
                    ['msgs-total',      'Total',          true]],
       'Network': [['from_client',  'From client',  true],

--- a/priv/www/js/tmpl/overview.ejs
+++ b/priv/www/js/tmpl/overview.ejs
@@ -23,7 +23,7 @@
         if (vhosts[i].cluster_state[vhost_status_node] != 'running') {
 %>
 <p class="warning">
-  Virtual host <b><%= vhosts[i].name %></b> experienced an error on node <b><%= vhost_status_node %></b> and can be inaccessible
+  Virtual host <b><%= vhosts[i].name %></b> experienced an error on node <b><%= vhost_status_node %></b> and may be inaccessible
 </p>
 <% }}} %>
 </div>

--- a/priv/www/js/tmpl/overview.ejs
+++ b/priv/www/js/tmpl/overview.ejs
@@ -17,11 +17,15 @@
   <% } %>
 </p>
 <% } %>
-<% for (i = 0; i < vhosts.length; i++) { if (vhosts[i].state == 'down') { %>
+<% for (i = 0; i < vhosts.length; i++)
+{
+    for (var vhost_status_node in vhosts[i].cluster_state) {
+        if (vhosts[i].cluster_state[vhost_status_node] != 'running') {
+%>
 <p class="warning">
-  Virtual host <b><%= vhosts[i].name %></b> experienced an error and is inaccessible
+  Virtual host <b><%= vhosts[i].name %></b> experienced an error on node <b><%= vhost_status_node %></b> and can be inaccessible
 </p>
-<% }} %>
+<% }}} %>
 </div>
 
 <div class="section">

--- a/priv/www/js/tmpl/vhost.ejs
+++ b/priv/www/js/tmpl/vhost.ejs
@@ -22,7 +22,16 @@
         <td><%= fmt_boolean(vhost.tracing) %></td>
       <tr>
         <th>State:</th>
-        <td><%= vhost.cluster_state %></td>
+        <td>
+        <table class="mini">
+        <% for (var node in vhost.cluster_state) { %>
+            <tr>
+            <th><%= fmt_escape_html(node) %> :</th>
+            <td><%= vhost.cluster_state[node] %></td>
+            </tr>
+        <% } %>
+        </table>
+        </td>
       </tr>
     </table>
 </div>

--- a/priv/www/js/tmpl/vhost.ejs
+++ b/priv/www/js/tmpl/vhost.ejs
@@ -22,7 +22,7 @@
         <td><%= fmt_boolean(vhost.tracing) %></td>
       <tr>
         <th>State:</th>
-        <td><%= vhost.state %></td>
+        <td><%= vhost.cluster_state %></td>
       </tr>
     </table>
 </div>

--- a/priv/www/js/tmpl/vhosts.ejs
+++ b/priv/www/js/tmpl/vhosts.ejs
@@ -9,7 +9,7 @@
 <table class="list">
   <thead>
   <tr>
-    <th colspan="3">Overview</th>
+    <%= group_heading('vhosts', 'Overview', [true, true, true]) %>
     <%= group_heading('vhosts', 'Messages', []) %>
     <%= group_heading('vhosts', 'Network', []) %>
 <% if (rates_mode != 'none') { %>
@@ -21,6 +21,9 @@
       <th><%= fmt_sort('Name', 'name') %></th>
       <th>Users <span class="help" id="internal-users-only"></span></th>
       <th>State</th>
+<% if (show_column('vhosts',           'cluster-state')) { %>
+      <th>Cluster state</th>
+<% } %>
 <% if (show_column('vhosts',           'msgs-ready')) { %>
       <th><%= fmt_sort('Ready',        'messages_ready') %></th>
 <% } %>
@@ -55,7 +58,26 @@
          <td><%= link_vhost(vhost.name) %></td>
          <td class="c"><%= fmt_permissions(vhost, permissions, 'vhost', 'user',
                            '<p class="warning">No users</p>') %></td>
-         <td><%= vhost.state %></td>
+         <td><%= fmt_vhost_state(vhost) %></td>
+<% if (show_column('vhosts', 'cluster-state')) { %>
+         <td>
+             <table>
+             <tbody>
+            <%
+            for (var node in vhost.cluster_state) {
+                var state = vhost.cluster_state[node];
+            %>
+            <tr>
+            <td><%= node %></td>
+            <td><%= state %></td>
+            </tr>
+            <%
+            }
+            %>
+             </tbody>
+             </table>
+         </td>
+<% } %>
 <% if (show_column('vhosts', 'msgs-ready')) { %>
    <td class="r"><%= fmt_num_thousands(vhost.messages_ready) %></td>
 <% } %>

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -809,8 +809,9 @@ queues_test(Config) ->
 
     rabbit_ct_broker_helpers:force_vhost_failure(Config, <<"downvhost">>),
     %% The vhost is down
-    DownVHost = #{name => <<"downvhost">>, tracing => false, state => <<"down">>},
-    assert_item(DownVHost, http_get(Config, "/vhosts/downvhost")),
+    #{name := <<"downvhost">>, tracing := false, cluster_state := DownClusterState} =
+        http_get(Config, "/vhosts/downvhost"),
+    ?assertEqual([<<"stopped">>], lists:usort(maps:values(DownClusterState))),
 
     DownQueues = http_get(Config, "/queues/downvhost"),
     DownQueue  = http_get(Config, "/queues/downvhost/foo"),

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -344,15 +344,17 @@ vhosts_test(Config) ->
 
 vhosts_trace_test(Config) ->
     http_put(Config, "/vhosts/myvhost", none, {group, '2xx'}),
-    Disabled = #{name => <<"myvhost">>, tracing => false, state => <<"running">>},
-    Enabled  = #{name => <<"myvhost">>, tracing => true, state => <<"running">>},
-    Disabled = http_get(Config, "/vhosts/myvhost"),
+    ?assertMatch(#{name := <<"myvhost">>, tracing := false,  cluster_state := _},
+                 http_get(Config, "/vhosts/myvhost")),
     http_put(Config, "/vhosts/myvhost", [{tracing, true}], {group, '2xx'}),
-    Enabled = http_get(Config, "/vhosts/myvhost"),
+    ?assertMatch(#{name := <<"myvhost">>, tracing := true, cluster_state := _},
+                 http_get(Config, "/vhosts/myvhost")),
     http_put(Config, "/vhosts/myvhost", [{tracing, true}], {group, '2xx'}),
-    Enabled = http_get(Config, "/vhosts/myvhost"),
+    ?assertMatch(#{name := <<"myvhost">>, tracing := true},
+                 http_get(Config, "/vhosts/myvhost")),
     http_put(Config, "/vhosts/myvhost", [{tracing, false}], {group, '2xx'}),
-    Disabled = http_get(Config, "/vhosts/myvhost"),
+    ?assertMatch(#{name := <<"myvhost">>, tracing := false},
+                 http_get(Config, "/vhosts/myvhost")),
     http_delete(Config, "/vhosts/myvhost", {group, '2xx'}),
 
     passed.


### PR DESCRIPTION
Vhost supervisor status can be different on different nodes.
Report a warning if a vhost is down on any node.
State can be calculated from the cluster state.

Requires https://github.com/rabbitmq/rabbitmq-server/pull/1318

Fixes #460
[#149634421]