### PR TITLE
Authorize users tagged with "administrator" to perform vhost-scoped operations

### DIFF
--- a/priv/www/js/formatters.js
+++ b/priv/www/js/formatters.js
@@ -633,7 +633,7 @@ function link_conn(name, desc) {
 }
 
 function link_channel(name) {
-    return _link_to(short_chan(name), '#/channels/' + esc(name))
+    return _link_to(short_chan(name), '#/channels/' + esc(name));
 }
 
 function link_exchange(vhost, name, args) {
@@ -646,19 +646,19 @@ function link_queue(vhost, name, args) {
 }
 
 function link_vhost(name) {
-    return _link_to(name, '#/vhosts/' + esc(name))
+    return _link_to(name, '#/vhosts/' + esc(name));
 }
 
 function link_user(name) {
-    return _link_to(name, '#/users/' + esc(name))
+    return _link_to(name, '#/users/' + esc(name));
 }
 
 function link_node(name) {
-    return _link_to(name, '#/nodes/' + esc(name))
+    return _link_to(name, '#/nodes/' + esc(name));
 }
 
 function link_policy(vhost, name) {
-    return _link_to(name, '#/policies/' + esc(vhost) + '/' + esc(name))
+    return _link_to(name, '#/policies/' + esc(vhost) + '/' + esc(name));
 }
 
 function _link_to(name, url, highlight, args) {

--- a/priv/www/js/tmpl/topic-permissions.ejs
+++ b/priv/www/js/tmpl/topic-permissions.ejs
@@ -76,10 +76,9 @@ for (var i = 0; i < topic_permissions.length; i++) {
         <tr>
           <th><label>Exchange:</label></th>
           <td>
-          <% console.log(exchanges) %>
-           <div id='list-exchanges'>
+          <div id='list-exchanges'>
             <%= format('list-exchanges', {'exchanges': exchanges}) %>
-           </div>
+          </div>
           </td>
         </tr>
         <tr>

--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -92,8 +92,8 @@ is_authorized_monitor(ReqData, Context) ->
 is_authorized_vhost(ReqData, Context) ->
     is_authorized(ReqData, Context,
                   <<"User not authorised to access virtual host">>,
-                  fun(User) ->
-                          user_matches_vhost(ReqData, User)
+                  fun(#user{tags = Tags} = User) ->
+                          is_admin(Tags) orelse user_matches_vhost(ReqData, User)
                   end).
 
 is_authorized_vhost_visible(ReqData, Context) ->

--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -136,8 +136,9 @@ is_authorized_policies(ReqData, Context) ->
     is_authorized(ReqData, Context,
                   <<"User not authorised to access object">>,
                   fun(User = #user{tags = Tags}) ->
-                          is_policymaker(Tags) andalso
-                              user_matches_vhost(ReqData, User)
+                          is_admin(Tags) orelse
+                                           (is_policymaker(Tags) andalso
+                                            user_matches_vhost(ReqData, User))
                   end).
 
 %% For global parameters. Must be policymaker.

--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -99,8 +99,8 @@ is_authorized_vhost(ReqData, Context) ->
 is_authorized_vhost_visible(ReqData, Context) ->
     is_authorized(ReqData, Context,
                   <<"User not authorised to access virtual host">>,
-                  fun(User) ->
-                          user_matches_vhost_visible(ReqData, User)
+                  fun(#user{tags = Tags} = User) ->
+                          is_admin(Tags) orelse user_matches_vhost_visible(ReqData, User)
                   end).
 
 user_matches_vhost(ReqData, User) ->
@@ -877,7 +877,12 @@ all_or_one_vhost(ReqData, Fun) ->
     end.
 
 filter_vhost(List, ReqData, Context) ->
-    VHosts = list_login_vhosts(Context#context.user, cowboy_req:get(socket, ReqData)),
+    User = #user{tags = Tags} = Context#context.user,
+    Fn   = case is_admin(Tags) of
+               true  -> fun list_visible_vhosts/2;
+               false -> fun list_login_vhosts/2
+           end,
+    VHosts = Fn(User, cowboy_req:get(socket, ReqData)),
     [I || I <- List, lists:member(pget(vhost, I), VHosts)].
 
 filter_user(List, _ReqData, #context{user = User}) ->
@@ -924,12 +929,9 @@ is_mgmt_user(T)   -> intersects(T, [administrator, monitoring, policymaker,
 intersects(A, B) -> lists:any(fun(I) -> lists:member(I, B) end, A).
 
 %% The distinction between list_visible_vhosts and list_login_vhosts
-%% is there to ensure that admins / monitors can always learn of the
+%% is there to ensure that monitors can always learn of the
 %% existence of all vhosts, and can always see their contribution to
-%% global stats. However, if an admin / monitor does not have any
-%% permissions for a vhost, it's probably less confusing to make that
-%% prevent them from seeing "into" it, than letting them see stuff
-%% that they then can't touch.
+%% global stats.
 
 list_visible_vhosts(User) ->
     list_visible_vhosts(User, undefined).


### PR DESCRIPTION
This way an administrator without any permissions can access every form
on pages such as user permission management. Some users and RabbitMQ team
members administrators should have unconditional access to all vhosts.

Closes #461.

Per discussion with @acogoluegnes @lukebakken @hairyhum @dumbbell.