### PR TITLE
API to restart a crashed vhost.

### DIFF
--- a/priv/www/api/index.html
+++ b/priv/www/api/index.html
@@ -672,6 +672,14 @@ Content-Length: 0</pre>
         <td>A list of all topic permissions for a given virtual host.</td>
       </tr>
       <tr>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td>X</td>
+        <td class="path">/api/vhosts/<i>name</i>/start/<i>node</i></td>
+        <td>Starts virtual host <i>name</i> on node <i>node</i>.</td>
+      </tr>
+      <tr>
         <td>X</td>
         <td></td>
         <td></td>

--- a/priv/www/css/main.css
+++ b/priv/www/css/main.css
@@ -235,6 +235,7 @@ table.two-col-layout > tbody > tr > td { width: 50%; vertical-align: top; }
 
 input[type=submit], button { padding: 8px; border-radius: 5px; -moz-border-radius: 5px; color: black !important; text-decoration: none; cursor: pointer; font-weight: normal; }
 table.list input[type=submit], table.list button { padding: 4px; }
+table.mini input[type=submit], table.mini button { padding: 4px; }
 
 input[type=submit], button {
     background: #ddf;

--- a/priv/www/js/dispatcher.js
+++ b/priv/www/js/dispatcher.js
@@ -282,6 +282,9 @@ dispatcher_add(function(sammy) {
             }
         }
     });
+    sammy.post('#/restart_vhost', function(){
+        if(sync_post(this, '/vhosts/:vhost/start/:node')) update();
+    })
     sammy.del('#/limits', function() {
         if (sync_delete(this, '/vhost-limits/:vhost/:name')) update();
     });

--- a/priv/www/js/tmpl/vhost.ejs
+++ b/priv/www/js/tmpl/vhost.ejs
@@ -27,7 +27,15 @@
         <% for (var node in vhost.cluster_state) { %>
             <tr>
             <th><%= fmt_escape_html(node) %> :</th>
-            <td><%= vhost.cluster_state[node] %></td>
+            <td><%= vhost.cluster_state[node] %>
+            <% if (vhost.cluster_state[node] == "stopped"){ %>
+                <form action="#/restart_vhost" method="post">
+                    <input type="hidden" name="node" value="<%= node %>"/>
+                    <input type="hidden" name="vhost" value="<%= vhost.name %>"/>
+                    <input type="submit" value="Restart"/>
+                </form>
+            <% } %>
+            </td>
             </tr>
         <% } %>
         </table>

--- a/priv/www/js/tmpl/vhosts.ejs
+++ b/priv/www/js/tmpl/vhosts.ejs
@@ -69,7 +69,16 @@
             %>
             <tr>
             <td><%= node %></td>
-            <td><%= state %></td>
+            <td>
+            <%= state %>
+            <% if (state == "stopped"){ %>
+                <form action="#/restart_vhost" method="post" class="confirm">
+                    <input type="hidden" name="node" value="<%= node %>"/>
+                    <input type="hidden" name="vhost" value="<%= vhost.name %>"/>
+                    <input type="submit" value="Restart"/>
+                </form>
+            <% } %>
+            </td>
             </tr>
             <%
             }

--- a/src/rabbit_mgmt_dispatcher.erl
+++ b/src/rabbit_mgmt_dispatcher.erl
@@ -117,6 +117,7 @@ dispatcher() ->
      {"/bindings/:vhost/e/:source/:dtype/:destination/:props", rabbit_mgmt_wm_binding, []},
      {"/vhosts",                                               rabbit_mgmt_wm_vhosts, []},
      {"/vhosts/:vhost",                                        rabbit_mgmt_wm_vhost, []},
+     {"/vhosts/:vhost/start/:node",                            rabbit_mgmt_wm_vhost_restart, []},
      {"/vhosts/:vhost/permissions",                            rabbit_mgmt_wm_permissions_vhost, []},
      {"/vhosts/:vhost/topic-permissions",                      rabbit_mgmt_wm_topic_permissions_vhost, []},
      %% /connections/:connection is already taken, we cannot use our standard scheme here

--- a/src/rabbit_mgmt_wm_vhost_restart.erl
+++ b/src/rabbit_mgmt_wm_vhost_restart.erl
@@ -1,0 +1,67 @@
+%%   The contents of this file are subject to the Mozilla Public License
+%%   Version 1.1 (the "License"); you may not use this file except in
+%%   compliance with the License. You may obtain a copy of the License at
+%%   http://www.mozilla.org/MPL/
+%%
+%%   Software distributed under the License is distributed on an "AS IS"
+%%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%%   License for the specific language governing rights and limitations
+%%   under the License.
+%%
+%%   The Original Code is RabbitMQ Management Plugin.
+%%
+%%   The Initial Developer of the Original Code is GoPivotal, Inc.
+%%   Copyright (c) 2011-2012 GoPivotal, Inc.  All rights reserved.
+%%
+
+-module(rabbit_mgmt_wm_vhost_restart).
+
+-export([init/3, rest_init/2, resource_exists/2, is_authorized/2,
+         allowed_methods/2, content_types_accepted/2, accept_content/2]).
+-export([variances/2]).
+
+-include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+
+%%--------------------------------------------------------------------
+
+init(_, _, _) -> {upgrade, protocol, cowboy_rest}.
+
+rest_init(Req, _Config) ->
+    {ok, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+
+variances(Req, Context) ->
+    {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
+
+allowed_methods(ReqData, Context) ->
+    {[<<"POST">>, <<"OPTIONS">>], ReqData, Context}.
+
+resource_exists(ReqData, Context) ->
+    VHost = id(ReqData),
+    {rabbit_vhost:exists(VHost), ReqData, Context}.
+
+content_types_accepted(ReqData, Context) ->
+   {[{'*', accept_content}], ReqData, Context}.
+
+accept_content(ReqData, Context) ->
+    VHost = id(ReqData),
+    NodeB = rabbit_mgmt_util:id(node, ReqData),
+    Node  = binary_to_atom(NodeB, utf8),
+    case rabbit_vhost_sup_sup:start_vhost(VHost, Node) of
+        {ok, _} ->
+            {true, ReqData, Context};
+        {error, {already_started, _}} ->
+            {true, ReqData, Context};
+        {error, Err} ->
+            Message = io_lib:format("Request to node ~s failed with ~p",
+                                    [Node, Err]),
+            rabbit_mgmt_util:bad_request(list_to_binary(Message), ReqData, Context)
+    end.
+
+is_authorized(ReqData, Context) ->
+    rabbit_mgmt_util:is_authorized_admin(ReqData, Context).
+
+%%--------------------------------------------------------------------
+
+id(ReqData) ->
+    rabbit_mgmt_util:id(vhost, ReqData).


### PR DESCRIPTION
Administrator should be able to restart vhosts if they believe
it can be recovered.
Added buttons to vhost status tables and
the new HTTP API endpoint: /vhosts/:vhost/start/:node

Part of rabbitmq/rabbitmq-server#1321
[#149484305]