### PR TITLE
Format node names consistently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .*.sw?
 *.beam
 *.pem
+erl_crash.dump
+MnesiaCore.*
 .erlang.mk/
 /cover/
 /debug/

--- a/priv/www/js/formatters.js
+++ b/priv/www/js/formatters.js
@@ -494,19 +494,8 @@ function fmt_maybe_wrap(txt, encoding) {
     return fmt_escape_html(res);
 }
 
-// Note: since the default node name is 'rabbit'
-// we strip it off here to save UI space
 function fmt_node(node_host) {
-    var fmt_node_re = /^rabbit@(.*)$/;
-    function do_fmt_node(nh) {
-        var rslt = null;
-        if (rslt = fmt_node_re.exec(nh)) {
-            return fmt_string(rslt[1]);
-        } else {
-            return fmt_string(nh);
-        }
-    };
-    return do_fmt_node(node_host);
+    return fmt_string(node_host);
 }
 
 function fmt_object_state(obj) {

--- a/priv/www/js/formatters.js
+++ b/priv/www/js/formatters.js
@@ -7,8 +7,12 @@ PROCESS_THRESHOLDS=[[0.75, 'red'],
                     [0.5, 'yellow']];
 
 function fmt_string(str, unknown) {
-    if (unknown == undefined) unknown = UNKNOWN_REPR;
-    if (str == undefined) return unknown;
+    if (unknown == undefined) {
+        unknown = UNKNOWN_REPR;
+    }
+    if (str == undefined) {
+        return unknown;
+    }
     return fmt_escape_html("" + str);
 }
 
@@ -490,11 +494,19 @@ function fmt_maybe_wrap(txt, encoding) {
     return fmt_escape_html(res);
 }
 
+// Note: since the default node name is 'rabbit'
+// we strip it off here to save UI space
 function fmt_node(node_host) {
-    var both = node_host.split('@');
-    var node = both.slice(0, 1);
-    var host = both.slice(1);
-    return node == 'rabbit' ? host : (node + '@' + host);
+    var fmt_node_re = /^rabbit@(.*)$/;
+    function do_fmt_node(nh) {
+        var rslt = null;
+        if (rslt = fmt_node_re.exec(nh)) {
+            return fmt_string(rslt[1]);
+        } else {
+            return fmt_string(nh);
+        }
+    };
+    return do_fmt_node(node_host);
 }
 
 function fmt_object_state(obj) {
@@ -643,7 +655,7 @@ function link_user(name) {
 }
 
 function link_node(name) {
-    return _link_to(name, '#/nodes/' + esc(name))
+    return _link_to(fmt_node(name), '#/nodes/' + esc(name))
 }
 
 function link_policy(vhost, name) {

--- a/priv/www/js/tmpl/overview.ejs
+++ b/priv/www/js/tmpl/overview.ejs
@@ -72,7 +72,7 @@
 
 <div class="hider updatable">
 <% if (nodes.length == 1) { %>
-    <p>Node: <%= nodes[0].name %> <a href="#/nodes/<%= esc(nodes[0].name) %>">(More about this node)</a></p>
+    <p>Node: <%= fmt_node(nodes[0].name) %> <a href="#/nodes/<%= esc(nodes[0].name) %>">(More about this node)</a></p>
 <% } %>
 
 <table class="list">

--- a/priv/www/js/tmpl/partition.ejs
+++ b/priv/www/js/tmpl/partition.ejs
@@ -30,7 +30,7 @@
      var partition = partitions[i];
 %>
     <tr<%= alt_rows(i)%>>
-      <td><%= partition.node %></td>
+      <td><%= fmt_node(partition.node) %></td>
       <td>
 <%
    for (var j = 0; j < partition.others.length; j++) {

--- a/priv/www/js/tmpl/queues.ejs
+++ b/priv/www/js/tmpl/queues.ejs
@@ -223,7 +223,7 @@
           <td>
             <select name="node">
               <% for (var i = 0; i < nodes.length; i++) { %>
-              <option value="<%= nodes[i].name %>"><%= fmt_node(nodes[i].name) %></option>
+              <option value="<%= fmt_string(nodes[i].name) %>"><%= fmt_node(nodes[i].name) %></option>
               <% } %>
             </select>
           </td>

--- a/priv/www/js/tmpl/queues.ejs
+++ b/priv/www/js/tmpl/queues.ejs
@@ -223,7 +223,7 @@
           <td>
             <select name="node">
               <% for (var i = 0; i < nodes.length; i++) { %>
-              <option value="<%= fmt_string(nodes[i].name) %>"><%= nodes[i].name %></option>
+              <option value="<%= nodes[i].name %>"><%= fmt_node(nodes[i].name) %></option>
               <% } %>
             </select>
           </td>


### PR DESCRIPTION
This change ensures the node prefix is always displayed, even if it is the string `rabbit@`

Fixes #473 