### PR TITLE
Improve CONTRIBUTING.md, and add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,23 @@
+Thank you for using RabbitMQ and for taking the time to report an issue.
+
+*Important:* please first read the [`CONTRIBUTING`](../CONTRIBUTING.md) document in the root of this repository to be sure your issue shouldn't be discussed on the [mailing list][rmq-users] first.
+
+In order for the RabbitMQ team to investigate your issue, the following *must* be provided:
+  
+* Erlang version
+* RabbitMQ version
+* RabbitMQ plugin version(s)
+* Client library version (for all libraries used)
+* Operating system, version, and patchlevel
+* RabbitMQ, server and client application logs
+* A *complete*, working code sample, terminal transcript or set of instructions that can be used to reproduce the issue. We can't stress enough how much this helps!
+
+Running the [`rabbitmq-collect-env`][rmq-collect-env] script can provide most of the information needed. Please make the archive available via a third-party service and note that the script does *not* attempt to scrub any sensitive data.
+
+RabbitMQ Management information:
+
+* Browser and browser version
+* Operating system on which you are running your browser, and it's version
+
+[rmq-users]: https://groups.google.com/forum/#!forum/rabbitmq-users
+[rmq-collect-env]: https://github.com/rabbitmq/support-tools/blob/master/scripts/rabbitmq-collect-env

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,23 +1,38 @@
 Thank you for using RabbitMQ and for taking the time to report an issue.
 
-*Important:* please first read the [`CONTRIBUTING`](../CONTRIBUTING.md) document in the root of this repository to be sure your issue shouldn't be discussed on the [mailing list][rmq-users] first.
+## Does This Belong to GitHub or RabbitMQ Mailing List?
+
+*Important:* please first read the [`CONTRIBUTING`](../CONTRIBUTING.md) document in the root of this repository.
+It will help you determine whether your feedback should be directed to the [RabbitMQ mailing list][rmq-users]
+instead.
+
+## Please Help Maintainers and Contributors Help You
 
 In order for the RabbitMQ team to investigate your issue, the following *must* be provided:
   
-* Erlang version
 * RabbitMQ version
+* Erlang version
+* RabbitMQ server and client application log files
+* A runnable code sample, terminal transcript or detailed set of instructions that can be used to reproduce the issue
 * RabbitMQ plugin information via `rabbitmq-plugins list`
 * Client library version (for all libraries used)
-* Operating system, version, and patchlevel
-* RabbitMQ, server and client application logs
-* A working code sample, terminal transcript or detailed set of instructions that can be used to reproduce the issue
+* Operating system, version, and patch level
 
-Running the [`rabbitmq-collect-env`][rmq-collect-env] script can provide most of the information needed. Please make the archive available via a third-party service and note that the script does *not* attempt to scrub any sensitive data.
+Running the [`rabbitmq-collect-env`][rmq-collect-env] script can
+provide most of the information needed. Please make the archive
+available via a third-party service and note that **the script does
+not attempt to scrub any sensitive data**.
 
-RabbitMQ Management information:
+If your issue is with the RabbitMQ management UI or HTTP API, please also provide
+the following:
 
-* Browser and browser version
-* Operating system on which you are running your browser, and it's version
+ * Browser and its version
+ * What management UI page was used
+ * Operating system on which you are running your browser, and its version
+ * Errors reported in the JavaScript console (if any)
+
+This information **greatly speeds up issue investigation** (or makes it possible to investigate it at all).
+Please help project maintainers and contributors to help you by providing it!
 
 [rmq-users]: https://groups.google.com/forum/#!forum/rabbitmq-users
 [rmq-collect-env]: https://github.com/rabbitmq/support-tools/blob/master/scripts/rabbitmq-collect-env

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,11 +6,11 @@ In order for the RabbitMQ team to investigate your issue, the following *must* b
   
 * Erlang version
 * RabbitMQ version
-* RabbitMQ plugin version(s)
+* RabbitMQ plugin information via `rabbitmq-plugins list`
 * Client library version (for all libraries used)
 * Operating system, version, and patchlevel
 * RabbitMQ, server and client application logs
-* A *complete*, working code sample, terminal transcript or set of instructions that can be used to reproduce the issue. We can't stress enough how much this helps!
+* A working code sample, terminal transcript or detailed set of instructions that can be used to reproduce the issue
 
 Running the [`rabbitmq-collect-env`][rmq-collect-env] script can provide most of the information needed. Please make the archive available via a third-party service and note that the script does *not* attempt to scrub any sensitive data.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Proposed changes
+
+Describe the big picture of your changes here to communicate to the RabbitMQ team why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+
+## Types of changes
+
+What types of changes does your code introduce to this project?
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask on the mailing list. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+
+- [ ] I have read the [`CONTRIBUTING`](../CONTRIBUTING.md) document
+- [ ] I have signed the [CA](https://github.com/rabbitmq/ca#how-to-submit)
+- [ ] All tests pass locally with my changes
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added necessary documentation (if appropriate)
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+## Further comments
+
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,22 @@
-## Proposed changes
+## Proposed Changes
 
-Describe the big picture of your changes here to communicate to the RabbitMQ team why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+Please describe the big picture of your changes here to communicate to the RabbitMQ team
+why we should accept this pull request. If it fixes a bug or resolves a feature request,
+be sure to link to that issue.
 
-## Types of changes
+A pull request that doesn't explain **why** the change was made has a much lower chance of
+being accepted.
+
+If English isn't your first language, don't worry about it and try to communicate the problem
+you are trying to solve to the best of your abilities.
+As long as we can understand the intent, it's all good.
+
+## Types of Changes
 
 What types of changes does your code introduce to this project?
 _Put an `x` in the boxes that apply_
 
-- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation (correction or otherwise)
@@ -15,15 +24,20 @@ _Put an `x` in the boxes that apply_
 
 ## Checklist
 
-_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask on the mailing list. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+_Put an `x` in the boxes that apply. You can also fill these out after
+creating the PR. If you're unsure about any of them, don't hesitate to
+ask on the mailing list. We're here to help! This is simply a reminder
+of what we are going to look for before merging your code._
 
 - [ ] I have read the [`CONTRIBUTING`](../CONTRIBUTING.md) document
 - [ ] I have signed the [CA](https://github.com/rabbitmq/ca#how-to-submit)
 - [ ] All tests pass locally with my changes
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added necessary documentation (if appropriate)
-- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] Any dependent changes have been merged and published in related repositories
 
-## Further comments
+## Further Comments
 
-If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
+If this is a relatively large or complex change, kick off the
+discussion by explaining why you chose the solution you did and what
+alternatives you considered, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,8 @@ _Put an `x` in the boxes that apply_
 - [ ] Bugfix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation (correction or otherwise)
+- [ ] Cosmetics (whitespace, appearance)
 
 ## Checklist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,38 +1,60 @@
+Thank you for using RabbitMQ and for taking the time to contribute to the project.
+
 ## Overview
 
-RabbitMQ projects use pull requests to discuss, collaborate on and accept code contributions.
-Pull requests is the primary place of discussing code changes.
+### GitHub issues
 
-## How to Contribute
+Team RabbitMQ uses GitHub issues for _specific actionable items_ engineers can work on. This assumes the following:
 
-The process is fairly standard:
+* GitHub issues are not used for questions, investigations, root cause analysis, discussions of potential issues, etc (as defined by this team)
+* We have a certain amount of information to work with
+
+The team receives many questions through various venues every single day. Frequently, these questions do not include the necessary details the team needs to begin useful work. GitHub issues can very quickly turn into a something impossible to navigate and make sense of. Because of this, questions, investigations, root cause analysis, and discussions of potential features are all considered to be [mailing list][rmq-users] material. If you are unsure where to begin, the [RabbitMQ users mailing list][rmq-users] is the right place.
+
+Getting all the details necessary to reproduce an issue, make a conclusion or even form a hypothesis about what's happening can take a fair amount of time. Please help others help you by providing a way to reproduce the behavior you're observing, or at least sharing as much relevant information as possible on the [RabbitMQ users mailing list][rmq-users]:
+
+* Versions of the following:
+    * Operating system (distribution as well)
+    * RabbitMQ server
+    * All client libraries used
+    * RabbitMQ plugins (if applicable)
+* Server logs
+* A code example or terminal transcript that can be used to reproduce
+* Full exception stack traces (not a single line message)
+* `rabbitmqctl status` (and, if possible, `rabbitmqctl environment` output)
+* Other relevant details about the environment and workload, e.g. a traffic capture
+* Feel free to edit out hostnames and other potentially sensitive information.
+* As an alternative, the [`rabbitmq-collect-env`][rmq-collect-env] script will collect all of this information (and more). Please note that no effort is made to scrub any information that may be sensitive
+
+### Pull Requests
+
+RabbitMQ projects use pull requests to discuss, collaborate on and accept code contributions. Pull requests is the primary place of discussing code changes.
 
  * Fork the repository or repositories you plan on contributing to
- * Clone [RabbitMQ umbrella repository](https://github.com/rabbitmq/rabbitmq-public-umbrella)
- * `cd umbrella`, `make co`
- * Create a branch with a descriptive name in the relevant repositories
- * Make your changes, run tests, commit with a [descriptive message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), push to your fork
+ * Clone the [RabbitMQ umbrella repository][rmq-umbrella-repo]
+ * Run `make co` in the cloned umbrella repository to fetch dependencies into `deps/`
+ * Create a branch with a descriptive name in the relevant repositories in `deps/`
+ * Make your changes, run tests, commit with a [descriptive message][git-commit-msgs], push to your fork
  * Submit pull requests with an explanation what has been changed and **why**
- * Submit a filled out and signed [Contributor Agreement](https://github.com/rabbitmq/ca#how-to-submit) if needed (see below)
+ * Submit a filled out and signed [Contributor Agreement][ca-agreement] if needed (see below)
  * Be patient. We will get to your pull request eventually
 
-If what you are going to work on is a substantial change, please first ask the core team
-of their opinion on [RabbitMQ mailing list](https://groups.google.com/forum/#!forum/rabbitmq-users).
-
+If what you are going to work on is a substantial change, please first ask the core team for their opinion on the [RabbitMQ users mailing list][rmq-users].
 
 ## Code of Conduct
 
 See [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).
 
-
 ## Contributor Agreement
 
-If you want to contribute a non-trivial change, please submit a signed copy of our
-[Contributor Agreement](https://github.com/rabbitmq/ca#how-to-submit) around the time
-you submit your pull request. This will make it much easier (in some cases, possible)
-for the RabbitMQ team at Pivotal to merge your contribution.
-
+If you want to contribute a non-trivial change, please submit a signed copy of our [Contributor Agreement][ca-agreement] around the time you submit your pull request. This will make it much easier (in some cases, possible) for the RabbitMQ team at Pivotal to merge your contribution.
 
 ## Where to Ask Questions
 
-If something isn't clear, feel free to ask on our [mailing list](https://groups.google.com/forum/#!forum/rabbitmq-users).
+If something isn't clear, feel free to ask on our [mailing list][rmq-users].
+
+[rmq-collect-env]: https://github.com/rabbitmq/support-tools/blob/master/scripts/rabbitmq-collect-env
+[rmq-umbrella-repo]: https://github.com/rabbitmq/rabbitmq-public-umbrella
+[git-commit-msgs]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[rmq-users]: https://groups.google.com/forum/#!forum/rabbitmq-users
+[ca-agreement]: https://github.com/rabbitmq/ca#how-to-submit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,11 @@
 Thank you for using RabbitMQ and for taking the time to contribute to the project.
+This document has two main parts:
+
+ * when and how to file GitHub issues for RabbitMQ projects
+ * how to submit pull requests
+
+They intend to save you and RabbitMQ maintainers some time, so please
+take a moment to read through them.
 
 ## Overview
 
@@ -7,39 +14,65 @@ Thank you for using RabbitMQ and for taking the time to contribute to the projec
 Team RabbitMQ uses GitHub issues for _specific actionable items_ engineers can work on. This assumes the following:
 
 * GitHub issues are not used for questions, investigations, root cause analysis, discussions of potential issues, etc (as defined by this team)
-* We have a certain amount of information to work with
+* Enough information is provided by the reporter for maintainers to work with
 
-The team receives many questions through various venues every single day. Frequently, these questions do not include the necessary details the team needs to begin useful work. GitHub issues can very quickly turn into a something impossible to navigate and make sense of. Because of this, questions, investigations, root cause analysis, and discussions of potential features are all considered to be [mailing list][rmq-users] material. If you are unsure where to begin, the [RabbitMQ users mailing list][rmq-users] is the right place.
+The team receives many questions through various venues every single
+day. Frequently, these questions do not include the necessary details
+the team needs to begin useful work. GitHub issues can very quickly
+turn into a something impossible to navigate and make sense
+of. Because of this, questions, investigations, root cause analysis,
+and discussions of potential features are all considered to be
+[mailing list][rmq-users] material. If you are unsure where to begin,
+the [RabbitMQ users mailing list][rmq-users] is the right place.
 
-Getting all the details necessary to reproduce an issue, make a conclusion or even form a hypothesis about what's happening can take a fair amount of time. Please help others help you by providing a way to reproduce the behavior you're observing, or at least sharing as much relevant information as possible on the [RabbitMQ users mailing list][rmq-users]:
+Getting all the details necessary to reproduce an issue, make a
+conclusion or even form a hypothesis about what's happening can take a
+fair amount of time. Please help others help you by providing a way to
+reproduce the behavior you're observing, or at least sharing as much
+relevant information as possible on the [RabbitMQ users mailing
+list][rmq-users].
 
-* Versions of the following:
-    * Operating system (distribution as well)
-    * RabbitMQ server
-    * All client libraries used
-    * RabbitMQ plugins (if applicable)
-* Server logs
-* A code example or terminal transcript that can be used to reproduce
-* Full exception stack traces (not a single line message)
-* `rabbitmqctl status` (and, if possible, `rabbitmqctl environment` output)
-* Other relevant details about the environment and workload, e.g. a traffic capture
-* Feel free to edit out hostnames and other potentially sensitive information.
-* As an alternative, the [`rabbitmq-collect-env`][rmq-collect-env] script will collect all of this information (and more). Please note that no effort is made to scrub any information that may be sensitive
+Please provide versions of the software used:
+
+ * RabbitMQ server
+ * Erlang 
+ * Operating system version (and distribution, if applicable)
+ * All client libraries used
+ * RabbitMQ plugins (if applicable)
+
+The following pieces of information greatly help in investigating and reproducing issues.
+Please provide them!
+
+ * RabbitMQ server logs
+ * A code example or terminal transcript that can be used to reproduce
+ * Full exception stack traces (a single line message is not enough!)
+ * `rabbitmqctl report` and `rabbitmqctl environment` output
+ * Other relevant details about the environment and workload, e.g. a traffic capture
+ * Feel free to edit out hostnames and other potentially sensitive information.
+
+To make collecting much of this and other environment information, use
+the [`rabbitmq-collect-env`][rmq-collect-env] script. It will produce an archive with
+server logs, operating system logs, output of certain diagnostics commands and so on.
+Please note that **no effort is made to scrub any information that may be sensitive**.
 
 ### Pull Requests
 
-RabbitMQ projects use pull requests to discuss, collaborate on and accept code contributions. Pull requests is the primary place of discussing code changes.
+RabbitMQ projects use pull requests to discuss, collaborate on and accept code contributions.
+Pull requests is the primary place of discussing code changes.
+
+Here's the recommended workflow:
 
  * Fork the repository or repositories you plan on contributing to
  * Clone the [RabbitMQ umbrella repository][rmq-umbrella-repo]
  * Run `make co` in the cloned umbrella repository to fetch dependencies into `deps/`
  * Create a branch with a descriptive name in the relevant repositories in `deps/`
- * Make your changes, run tests, commit with a [descriptive message][git-commit-msgs], push to your fork
+ * Make your changes, run tests (usually with `make tests`), commit with a [descriptive message][git-commit-msgs], push to your fork
  * Submit pull requests with an explanation what has been changed and **why**
  * Submit a filled out and signed [Contributor Agreement][ca-agreement] if needed (see below)
  * Be patient. We will get to your pull request eventually
 
-If what you are going to work on is a substantial change, please first ask the core team for their opinion on the [RabbitMQ users mailing list][rmq-users].
+If what you are going to work on is a substantial change, please first
+ask the core team for their opinion on the [RabbitMQ users mailing list][rmq-users].
 
 ## Code of Conduct
 
@@ -47,7 +80,11 @@ See [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).
 
 ## Contributor Agreement
 
-If you want to contribute a non-trivial change, please submit a signed copy of our [Contributor Agreement][ca-agreement] around the time you submit your pull request. This will make it much easier (in some cases, possible) for the RabbitMQ team at Pivotal to merge your contribution.
+If you want to contribute a non-trivial change, please submit a signed
+copy of our [Contributor Agreement][ca-agreement] around the time you
+submit your pull request. This will make it much easier (in some
+cases, possible) for the RabbitMQ team at Pivotal to merge your
+contribution.
 
 ## Where to Ask Questions
 


### PR DESCRIPTION
This change is intended to reduce the number of GitHub issues and pull requests that we must close outright due to lack of information. Users are urged to first discuss on `rabbitmq-users` and then only open an issue or pull request in appropriate situations.

#150971897