### PR TITLE
Report unused memory in different color.

### DIFF
--- a/priv/www/css/main.css
+++ b/priv/www/css/main.css
@@ -116,6 +116,7 @@ div.memory_conn   { background: #dada66; }
 div.memory_proc   { background: #6abf59; }
 div.memory_table  { background: #6679da; }
 div.memory_system { background: #999; }
+div.memory_unused { background: #955; }
 
 div.memory-bar div.memory_queue  { border-right: solid 1px #eb50a6; }
 div.memory-bar div.memory_binary { border-right: solid 1px #eb50a6; }
@@ -123,6 +124,7 @@ div.memory-bar div.memory_conn   { border-right: solid 1px #ebeb8d; }
 div.memory-bar div.memory_proc   { border-right: solid 1px #79da66; }
 div.memory-bar div.memory_table  { border-right: solid 1px #8d9ceb; }
 div.memory-bar div.memory_system { border-right: solid 1px #bbb; }
+div.memory-bar div.memory_unused { border-right: solid 1px #bbb; }
 
 sub { display: block; font-size: 0.8em; color: #888; }
 small { font-size: 0.8em; color: #888; }

--- a/priv/www/js/tmpl/memory.ejs
+++ b/priv/www/js/tmpl/memory.ejs
@@ -42,7 +42,7 @@ var key = [[{name: 'Queues', colour: 'queue',
                     ['connection_other',    'other']]}],
 
            [{name: 'Tables', colour: 'table',
-             keys: [['mnesia',              'mnesia'],
+             keys: [['mnesia',              'internal database tables'],
                     ['msg_index',           'message store index'],
                     ['mgmt_db',             'management database'],
                     ['other_ets',           'other']]}],
@@ -56,9 +56,9 @@ var key = [[{name: 'Queues', colour: 'queue',
                     ['other_system',        'other']
                     ]}],
 
-            [{name: 'Unused memory', colour: 'unused',
-              keys: [['allocated_unused',     'allocated unused'],
-                     ['reserved_unallocated', 'unallocated reserved by the OS']]}]];
+            [{name: 'Preallocated memory', colour: 'unused',
+              keys: [['allocated_unused',     'preallocated by runtime, unused'],
+                     ['reserved_unallocated', 'unallocated, reserved by the OS']]}]];
 %>
 <%= format('memory-table', {key: key, memory: memory}) %>
 </div>

--- a/priv/www/js/tmpl/memory.ejs
+++ b/priv/www/js/tmpl/memory.ejs
@@ -21,7 +21,9 @@
                   'other_proc'          : ['proc',   'Other process memory'],
                   'code'                : ['system', 'Code'],
                   'atom'                : ['system', 'Atoms'],
-                  'other_system'        : ['system', 'Other system']};
+                  'other_system'        : ['system', 'Other system'],
+                  'allocated_unused'    : ['unused', 'Allocated unused'],
+                  'reserved_unallocated': ['unused', 'Unallocated reserved by the OS']};
 %>
 <%= format('memory-bar', {sections: sections, memory: memory, total_out: []}) %>
 <span class="clear">&nbsp;</span>
@@ -51,7 +53,12 @@ var key = [[{name: 'Queues', colour: 'queue',
             {name: 'System', colour: 'system',
              keys: [['code',                'code'],
                     ['atom',                'atoms'],
-                    ['other_system',        'other']]}]];
+                    ['other_system',        'other']
+                    ]}],
+
+            [{name: 'Unused memory', colour: 'unused',
+              keys: [['allocated_unused',     'allocated unused'],
+                     ['reserved_unallocated', 'unallocated reserved by the OS']]}]];
 %>
 <%= format('memory-table', {key: key, memory: memory}) %>
 </div>

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -219,7 +219,7 @@ memory_test(Config) ->
     Keys = [total, connection_readers, connection_writers, connection_channels,
             connection_other, queue_procs, queue_slave_procs, plugins,
             other_proc, mnesia, mgmt_db, msg_index, other_ets, binary, code,
-            atom, other_system],
+            atom, other_system, allocated_unused, reserved_unallocated],
     assert_keys(Keys, pget(memory, Result)),
     http_get(Config, "/nodes/nonode/memory", ?NOT_FOUND),
     %% Relative memory as a percentage of the total


### PR DESCRIPTION
If `rss` or `allocator` memory calculation strategy is used,
show the unallocated and unused memory using other color then
system memory.

Addresses #499 
Requires https://github.com/rabbitmq/rabbitmq-server/pull/1404 https://github.com/rabbitmq/rabbitmq-common/pull/236
[#151472607]