### PR TITLE
Use `rss` memory to calculate the percentages

### DIFF
--- a/src/rabbit_mgmt_wm_node_memory.erl
+++ b/src/rabbit_mgmt_wm_node_memory.erl
@@ -70,10 +70,10 @@ augment(Mode, ReqData) ->
 format(absolute, Result) ->
     Result;
 format(relative, Result) ->
-    {value, {strategy, Strategy}, Rest0} = lists:keytake(strategy, 1, Result),
-    {value, {total, Totals}, Rest} = lists:keytake(total, 1, Rest0),
-    Total = proplists:get_value(Strategy, Totals),
-    [{total, 100} | [{K, percentage(V, Total)} || {K, V} <- Rest]].
+    {value, {total, Totals}, Rest} = lists:keytake(total, 1, Result),
+    Total = proplists:get_value(rss, Totals),
+    [{total, 100} | [{K, percentage(V, Total)} || {K, V} <- Rest,
+                                                  K =/= strategy]].
 
 percentage(Part, Total) ->
     case round((Part/Total) * 100) of


### PR DESCRIPTION
Now the breakdown always includes `allocated_unused` and `reserved_unallocated`.

`rabbit_mgmt_http_SUITE:memory_test` should be more stable now, with only minor variations around 100%.