### PR TITLE
Fix multiple event addition

### DIFF
--- a/priv/www/js/main.js
+++ b/priv/www/js/main.js
@@ -534,10 +534,6 @@ function postprocess() {
                            "after deletion.");
         });
 
-    $('div.section h2, div.section-hidden h2').on('click', function() {
-            toggle_visibility($(this));
-        });
-
     $('label').map(function() {
             if ($(this).attr('for') == '') {
                 var id = 'auto-label-' + Math.floor(Math.random()*1000000000);
@@ -733,7 +729,8 @@ function postprocess_partial() {
 
     setup_visibility();
 
-    $('.updatable div.section h2, .updatable div.section-hidden h2').on('click', function() {
+    $('#main').off('click', 'div.section h2, div.section-hidden h2');
+    $('#main').on('click', 'div.section h2, div.section-hidden h2', function() {
             toggle_visibility($(this));
         });
 


### PR DESCRIPTION
To reproduce:

* Open management UI, choose "no refresh"
* Force-refresh the page
* Go to node overview, and click a section expander
* You should see the section pop open and then closed again (or vice versa)

An initial page load calls both `postprocess` and `postprocess_partial`, resulting in duplicate event handlers being registered.

The change just nukes the existing handlers first before adding them again.