### PR TITLE
adjust the Select dropdown width to auto

### DIFF
--- a/priv/www/css/main.css
+++ b/priv/www/css/main.css
@@ -282,13 +282,13 @@ table.form { margin-bottom: 0.5em; }
 table.form th { text-align: right; vertical-align: top; }
 table.form input[type=text], table.form input[type=password] { width: 200px; }
 table.form input[type=text].wide, table.form input[type=password].wide { width: 300px; }
-table.form select { width: 200px; }
+table.form select { width: auto; }
 table.form select.narrow { width: 110px; }
 table.form .multifield { margin: 0; padding: 0; }
 table.form .multifield td { margin: 0; padding: 0; vertical-align: top; }
 table.form .multifield td.equals { padding: 3px; }
 table.form .multifield td input { float: left; }
-table.form .multifield td select { width: 70px; display: block; float: left; margin-left: 5px; }
+table.form .multifield td select { width: auto; display: block; float: left; margin-left: 5px; }
 table.form label { margin-top: 5px; display: block; }
 
 table.form table.subform { margin-bottom: 5px; }


### PR DESCRIPTION
Restricting the width of the select fields and its values truncates the visibility of the option values. Making it auto makes it fully visible. 

Fixes https://github.com/rabbitmq/rabbitmq-management/issues/519

I'm not a Frontend developer, so this fix may not be worthwhile, or it could impact negatively something somewhere else or it could be improved upon further. 

## Types of Changes

- [x ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [ x] I have read the `CONTRIBUTING.md` document
- [x ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories