### PR TITLE
Ensure content-type is only set once

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -223,7 +223,7 @@ reply(Facts, ReqData, Context) ->
     reply0(extract_columns(Facts, ReqData), ReqData, Context).
 
 reply0(Facts, ReqData, Context) ->
-    ReqData1 = set_resp_header(<<"Cache-Control">>, "no-cache", ReqData),
+    ReqData1 = set_resp_header(<<"cache-control">>, "no-cache", ReqData),
     try
         case cowboy_req:meta(media_type, ReqData1) of
             {{<<"application">>, <<"bert">>, _}, _} ->
@@ -873,9 +873,7 @@ post_respond({true, ReqData, Context}) ->
 post_respond({halt, ReqData, Context}) ->
     {halt, ReqData, Context};
 post_respond({JSON, ReqData, Context}) ->
-    {true, set_resp_header(
-             <<"Content-Type">>, "application/json",
-             cowboy_req:set_resp_body(JSON, ReqData)), Context}.
+    {true, cowboy_req:set_resp_body(JSON, ReqData), Context}.
 
 is_admin(T)       -> intersects(T, [administrator]).
 is_policymaker(T) -> intersects(T, [administrator, policymaker]).


### PR DESCRIPTION
As per the Cowboy 2.0 docs, header names should be lowercased binaries. `application/json` appears to be the default `content-type`, so no need to set it twice.

#153802689