### PR TITLE
Definitions import: coerce global parameter values that are maps to proplists

### DIFF
--- a/test/definitions_import_SUITE.erl
+++ b/test/definitions_import_SUITE.erl
@@ -19,6 +19,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
 -compile(export_all).
 
@@ -37,7 +38,8 @@ groups() ->
                                import_case1,
                                import_case2,
                                import_case3,
-                               import_case4
+                               import_case4,
+                               import_case5
                               ]}
     ].
 
@@ -79,6 +81,15 @@ import_case1(Config) -> import_case(Config, "case1").
 import_case2(Config) -> import_case(Config, "case2").
 import_case3(Config) -> import_case(Config, "case3").
 import_case4(Config) -> import_case(Config, "case4").
+
+import_case5(Config) ->
+    import_case(Config, "case5"),
+    ?assertEqual(rabbit_ct_broker_helpers:rpc(Config, 0,
+                                              rabbit_runtime_parameters, value_global,
+                                              [mqtt_port_to_vhost_mapping]),
+                 %% expect a proplist, see #528
+                 [{<<"1883">>,<<"/">>},
+                  {<<"1884">>,<<"vhost2">>}]).
 
 import_case(Config, CaseName) ->
     CasePath = filename:join(?config(data_dir, Config), CaseName ++ ".json"),

--- a/test/definitions_import_SUITE_data/case5.json
+++ b/test/definitions_import_SUITE_data/case5.json
@@ -1,0 +1,63 @@
+{
+  "rabbit_version": "3.7.2",
+  "users": [
+    {
+      "name": "guest",
+      "password_hash": "PD4MQV8Ivcprh1\/yUS9x7jkpbXtWIZLTQ0tvnZPncpI6Ui0a",
+      "hashing_algorithm": "rabbit_password_hashing_sha256",
+      "tags": "administrator"
+    }
+  ],
+  "vhosts": [
+    {
+      "name": "\/"
+    },
+    {
+      "name": "vhost2"
+    }
+  ],
+  "permissions": [
+    {
+      "user": "guest",
+      "vhost": "\/",
+      "configure": ".*",
+      "write": ".*",
+      "read": ".*"
+    },
+    {
+      "user": "guest",
+      "vhost": "vhost2",
+      "configure": ".*",
+      "write": ".*",
+      "read": ".*"
+    }
+  ],
+  "topic_permissions": [
+    
+  ],
+  "parameters": [
+    
+  ],
+  "global_parameters": [
+    {
+      "name": "mqtt_port_to_vhost_mapping",
+      "value": {
+        "1883": "\/",
+        "1884": "vhost2"
+      }
+    },
+    {
+      "name": "cluster_name",
+      "value": "rabbitmq@localhost"
+    }
+  ],
+  "policies": [
+  ],
+  "queues": [
+  ],
+  "exchanges": [
+  ],
+  "bindings": [
+    
+  ]
+}


### PR DESCRIPTION
To match what `rabbitmqctl set_global_parameter` does. Part of #528, together with https://github.com/rabbitmq/rabbitmq-common/pull/246, https://github.com/rabbitmq/rabbitmq-mqtt/pull/157.