### PR TITLE
Update user tags when password is cleared (v3.6.x)

### DIFF
--- a/src/rabbit_mgmt_wm_user.erl
+++ b/src/rabbit_mgmt_wm_user.erl
@@ -131,8 +131,9 @@ put_user(User, Version) ->
                     update_user_password_hash(Username, PasswordHash, Tags, User, Version);
                 {true, true} ->
                     throw({error, both_password_and_password_hash_are_provided});
-                %% clears password
+                %% clear password, update tags if needed
                 _ ->
+                    rabbit_auth_backend_internal:set_tags(Username, Tags),
                     rabbit_auth_backend_internal:clear_password(Username)
             end;
         false ->

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -74,6 +74,7 @@ all_tests() -> [
     user_credential_validation_accept_everything_succeeds_test,
     user_credential_validation_min_length_succeeds_test,
     user_credential_validation_min_length_fails_test,
+    updating_tags_of_a_passwordless_user_test,
     permissions_validation_test,
     permissions_list_test,
     permissions_test,
@@ -523,6 +524,35 @@ user_credential_validation_min_length_fails_test(Config) ->
     http_put(Config, "/users/abc", [{password, <<"_">>},
                                     {tags, <<"management">>}], ?BAD_REQUEST),
     rabbit_ct_broker_helpers:switch_credential_validator(Config, accept_everything).
+
+updating_tags_of_a_passwordless_user_test(Config) ->
+    rabbit_ct_broker_helpers:delete_user(Config, ?NON_GUEST_USERNAME),
+    http_put(Config, "/users/abc", [{tags,     <<"management">>},
+                                    {password, <<"myuser">>}], [?CREATED, ?NO_CONTENT]),
+
+    %% clear user's password
+    http_put(Config, "/users/abc", [{tags,     <<"management">>}], [?CREATED, ?NO_CONTENT]),
+    assert_item([{name, ?NON_GUEST_USERNAME},
+                  {tags, <<"management">>},
+                  {password_hash, <<>>},
+                  {hashing_algorithm, <<"rabbit_password_hashing_sha256">>}],
+                http_get(Config, "/users/abc")),
+
+    http_put(Config, "/users/abc", [{tags,     <<"impersonator">>}], [?CREATED, ?NO_CONTENT]),
+    assert_item([{name, ?NON_GUEST_USERNAME},
+                  {tags, <<"impersonator">>},
+                  {password_hash, <<>>},
+                  {hashing_algorithm, <<"rabbit_password_hashing_sha256">>}],
+                http_get(Config, "/users/abc")),
+
+    http_put(Config, "/users/abc", [{tags,     <<"">>}], [?CREATED, ?NO_CONTENT]),
+    assert_item([{name, ?NON_GUEST_USERNAME},
+                  {tags, <<"">>},
+                  {password_hash, <<>>},
+                  {hashing_algorithm, <<"rabbit_password_hashing_sha256">>}],
+                http_get(Config, "/users/abc")),
+
+    http_delete(Config, "/users/abc", ?NO_CONTENT).
 
 permissions_validation_test(Config) ->
     Good = [{configure, <<".*">>}, {write, <<".*">>}, {read, <<".*">>}],


### PR DESCRIPTION
## Proposed Changes

This makes sure user tags are updated even when user's password is cleared.

(cherry picked from commit 13199a582cbaa8ead7256d9c50460c9702aa2e08)

## Types of Changes

What types of changes does your code introduce to this project?

- [x] Bug fix (non-breaking change which fixes issue #533)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Further Comments

Fixes #533.

[#153436163]
