### PR TITLE
Update user tags when password is cleared (v3.7.x)

### DIFF
--- a/src/rabbit_mgmt_wm_user.erl
+++ b/src/rabbit_mgmt_wm_user.erl
@@ -127,8 +127,9 @@ put_user(User, Version, ActingUser) ->
                     update_user_password_hash(Username, PasswordHash, Tags, User, Version, ActingUser);
                 {true, true} ->
                     throw({error, both_password_and_password_hash_are_provided});
-                %% clears password
+                %% clear password, update tags if needed
                 _ ->
+                    rabbit_auth_backend_internal:set_tags(Username, Tags, ActingUser),
                     rabbit_auth_backend_internal:clear_password(Username, ActingUser)
             end;
         false ->


### PR DESCRIPTION
## Proposed Changes

This makes sure user tags are updated even when user's password is cleared.

## Types of Changes

What types of changes does your code introduce to this project?

- [x] Bug fix (non-breaking change which fixes issue #533)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Further Comments

Fixes #533.

[#153436163]
