### PR TITLE
Make requeue the default option in the Get Messages section to avoid accidentally deleting messages

### DIFF
--- a/priv/www/js/tmpl/queue.ejs
+++ b/priv/www/js/tmpl/queue.ejs
@@ -226,10 +226,10 @@
           <th><label>Ack Mode:</label></th>
           <td>
             <select name="ackmode">
-                <option value="ack_requeue_false">Ack message requeue false</option>
                 <option value="ack_requeue_true">Nack message requeue true</option>
-                <option value="reject_requeue_false">Reject requeue false</option>
+                <option value="ack_requeue_false">Ack message requeue false</option>
                 <option value="reject_requeue_true">Reject requeue true</option>
+                <option value="reject_requeue_false">Reject requeue false</option>
             </select>
           </td>
         </tr>


### PR DESCRIPTION
## Proposed Changes

Change the order of the Ack Mode drop down under the Get Messages section of a Queue so that requeue is the first / default option. 

The proposed change is so that users do not accidentally remove messages from the queue without confirming that they should be permanently deleted. This is only a UI change and does not affect any logic of the Get operation.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [X] Cosmetics (whitespace, appearance)
- [X] Usability (improved user interaction)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the mailing list. We're here to help! This is simply a reminder
of what we are going to look for before merging your code._

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Before:
![requeue-default-before](https://user-images.githubusercontent.com/6703/34992542-6b5cc08c-fac5-11e7-9456-36977f894c37.png)

After: 
![requeue-default-after](https://user-images.githubusercontent.com/6703/34992553-7341de86-fac5-11e7-9d41-a772743f0a86.png)
