### PR TITLE
include HTML charset

### DIFF
--- a/priv/www/api/index.html
+++ b/priv/www/api/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <html>
   <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>RabbitMQ Management HTTP API</title>
     <style>
       body { font: 12px Verdana,sans-serif; color: #444; padding: 8px 35px; }

--- a/priv/www/api/index.html
+++ b/priv/www/api/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <title>RabbitMQ Management HTTP API</title>
     <style>
       body { font: 12px Verdana,sans-serif; color: #444; padding: 8px 35px; }

--- a/priv/www/cli/index.html
+++ b/priv/www/cli/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <title>rabbitmqadmin</title>
     <style>
       body { font: 12px Verdana,sans-serif; color: #444; padding: 8px 35px; }

--- a/priv/www/cli/index.html
+++ b/priv/www/cli/index.html
@@ -1,5 +1,8 @@
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>rabbitmqadmin</title>
     <style>
       body { font: 12px Verdana,sans-serif; color: #444; padding: 8px 35px; }

--- a/priv/www/doc/stats.html
+++ b/priv/www/doc/stats.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <title>RabbitMQ Management HTTP Stats</title>
     <style>
       body { font: 12px Verdana,sans-serif; color: #444; padding: 8px 35px; }

--- a/priv/www/doc/stats.html
+++ b/priv/www/doc/stats.html
@@ -1,5 +1,8 @@
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>RabbitMQ Management HTTP Stats</title>
     <style>
       body { font: 12px Verdana,sans-serif; color: #444; padding: 8px 35px; }

--- a/priv/www/index.html
+++ b/priv/www/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <title>RabbitMQ Management</title>
     <script src="js/ejs-1.0.min.js" type="text/javascript"></script>
     <script src="js/jquery-1.12.4.min.js" type="text/javascript"></script>

--- a/priv/www/index.html
+++ b/priv/www/index.html
@@ -1,8 +1,8 @@
-<!doctype html>
-<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>RabbitMQ Management</title>
     <script src="js/ejs-1.0.min.js" type="text/javascript"></script>
     <script src="js/jquery-1.12.4.min.js" type="text/javascript"></script>

--- a/priv/www/index.html
+++ b/priv/www/index.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <html>
   <head>
     <title>RabbitMQ Management</title>


### PR DESCRIPTION
## Proposed Changes
The static HTML pages don't include a directive indicating the charset of the page content. This triggers an error statement printed in the developer console (though it's perfectly normal for the content at hand). So include a `<meta>` directive specifying UTF-8 charset.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Nothing else to ponder about.