### PR TITLE
Add management.path_prefix to Cuttlefish schema

### DIFF
--- a/priv/schema/rabbitmq_management.schema
+++ b/priv/schema/rabbitmq_management.schema
@@ -154,6 +154,14 @@ fun(Conf) ->
 end}.
 
 
+%% A custom path prefix for all HTTP request handlers.
+%%
+%% {path_prefix, "/a/prefix"},
+
+{mapping, "management.path_prefix", "rabbitmq_management.path_prefix",
+    [{datatype, string}]}.
+
+
 
 %% CORS
 

--- a/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -68,6 +68,15 @@
                       "test/config_schema_SUITE_data/certs/key.pem"}]}]}]}],
   [rabbitmq_management]},
 
+ {path_prefix,
+  "management.path_prefix = /a/prefix",
+  [
+   {rabbitmq_management, [
+                          {path_prefix, "/a/prefix"}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
  {cors_settings,
   "management.cors.allow_origins.1 = https://origin1.org
    management.cors.allow_origins.2 = https://origin2.org


### PR DESCRIPTION
## Proposed Changes

This adds `rabbitmq_management.path_prefix` to the new style config schema.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

A doc PR will be coming later.

Closes #547.

[#154880285]
