### PR TITLE
Remove unnecessary call to xmerl_ucs:from_utf8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endef
 
 DEPS = rabbit_common rabbit amqp_client cowboy cowlib rabbitmq_web_dispatch rabbitmq_management_agent
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers proper
-LOCAL_DEPS += xmerl mnesia ranch ssl crypto public_key
+LOCAL_DEPS += mnesia ranch ssl crypto public_key
 
 # FIXME: Add Ranch as a BUILD_DEPS to be sure the correct version is picked.
 # See rabbitmq-components.mk.

--- a/src/rabbit_mgmt_wm_queue_get.erl
+++ b/src/rabbit_mgmt_wm_queue_get.erl
@@ -162,13 +162,14 @@ maybe_truncate(Payload, Len) ->
 
 payload_part(Payload, Enc) ->
     {PL, E} = case Enc of
-                  auto -> try
-                              %% TODO mochijson does this but is it safe?
-                              _ = xmerl_ucs:from_utf8(Payload),
-                              {Payload, string}
-                          catch exit:{ucs, _} ->
-                                  {base64:encode(Payload), base64}
+                  auto -> case is_utf8(Payload) of
+                              true -> {Payload, string};
+                              false -> {base64:encode(Payload), base64}
                           end;
                   _    -> {base64:encode(Payload), base64}
               end,
     [{payload, PL}, {payload_encoding, E}].
+
+is_utf8(<<>>) -> true;
+is_utf8(<<_/utf8, Rest/bits>>) -> is_utf8(Rest);
+is_utf8(_) -> false.


### PR DESCRIPTION
This commit removes a call to xmerl_ucs:from_utf8 which was used
for two purposes: converting the binary payload into an Erlang
Unicode string (a list of integer code points), and validating
that the payload is indeed utf8.

The call was necessary when it was introduced because mochijson
only supported Unicode strings. Nowadays JSON libraries also
support utf8 binaries so converting is not necessary.

The function also starts by doing a binary_to_list/1 call which
creates a lot of garbage and can lead to OOM situations when the
queue is large. We ended up with the payload binary, the temporary
list and the final Unicode string in memory. With this patch we
only ever have the binary in memory.

To validate that the payload is utf8 and keep the functionality
intact a small function was added that makes use of the /utf8
binary matching specifier.

Since this was the only xmerl function used in the management
plugin I have also removed xmerl from the LOCAL_DEPS.

I have added a test for the different encodings that can be
requested to make sure that nothing was broken when doing
the change.
