### PR TITLE
 Add ha-promote-on-shutdown to policy definition fields (master)

### DIFF
--- a/priv/www/js/global.js
+++ b/priv/www/js/global.js
@@ -403,7 +403,9 @@ var HELP = {
     if <code>ha-mode</code> is <code>exactly</code>, or a list\
     of strings if <code>ha-mode</code> is <code>nodes</code>.',
 
-    'policy-ha-sync-mode' : 'One of <code>manual</code> or <code>automatic</code>.',
+    'policy-ha-sync-mode' : 'One of <code>manual</code> or <code>automatic</code>. <a target="_blank" href="http://www.rabbitmq.com/ha.html#unsynchronised-mirrors">Learn more</a>',
+
+    'policy-ha-promote-on-shutdown' : 'One of <code>when-synced</code> or <code>always</code>. <a target="_blank" href="http://www.rabbitmq.com/ha.html#unsynchronised-mirrors">Learn more</a>',
 
     'policy-federation-upstream-set' :
     'A string; only if the federation plugin is enabled. Chooses the name of a set of upstreams to use with federation, or "all" to use all upstreams. Incompatible with <code>federation-upstream</code>.',

--- a/priv/www/js/tmpl/policies.ejs
+++ b/priv/www/js/tmpl/policies.ejs
@@ -100,7 +100,8 @@
                 <td>
                   <span class="argument-link" field="definition" key="ha-mode" type="string">HA mode</span> <span class="help" id="policy-ha-mode"></span> |
                   <span class="argument-link" field="definition" key="ha-params" type="number">HA params</span> <span class="help" id="policy-ha-params"></span> |
-                  <span class="argument-link" field="definition" key="ha-sync-mode" type="string">HA sync mode</span> <span class="help" id="policy-ha-sync-mode"></span>
+                  <span class="argument-link" field="definition" key="ha-sync-mode" type="string">HA sync mode</span> <span class="help" id="policy-ha-sync-mode"></span> |
+                  <span class="argument-link" field="definition" key="ha-promote-on-shutdown" type="string" value="">HA mirror promotion</span> <span class="help" id="policy-ha-promote-on-shutdown"></span>
                 </td>
               </tr>
               <tr>

--- a/priv/www/js/tmpl/queues.ejs
+++ b/priv/www/js/tmpl/queues.ejs
@@ -1,3 +1,4 @@
+
 <h1>Queues</h1>
 <div class="section">
   <%= pagiante_ui(queues, 'queues') %>
@@ -258,7 +259,6 @@
                   <span class="argument-link" field="arguments" key="x-max-priority" type="number">Maximum priority</span> <span class="help" id="queue-max-priority"></span><br/>
                   <span class="argument-link" field="arguments" key="x-queue-mode" type="string" value="lazy">Lazy mode</span> <span class="help" id="queue-lazy"></span>
                   <span class="argument-link" field="arguments" key="x-queue-master-locator" type="string" value="">Master locator</span> <span class="help" id="queue-master-locator"></span>
-
                 </td>
               </tr>
             </table>

--- a/src/rabbit_mgmt_wm_definitions.erl
+++ b/src/rabbit_mgmt_wm_definitions.erl
@@ -184,7 +184,7 @@ apply_defs(Body, ActingUser, SuccessFun, ErrorFun) ->
                 for_all(permissions,        ActingUser, All, fun add_permission/2),
                 rabbit_log:info("Importing topic permissions..."),
                 for_all(topic_permissions,  ActingUser, All, fun add_topic_permission/2),
-                rabbit_log:info("Importing paramteres..."),
+                rabbit_log:info("Importing parameters..."),
                 for_all(parameters,         ActingUser, All, fun add_parameter/2),
                 rabbit_log:info("Importing global parameters..."),
                 for_all(global_parameters,  ActingUser, All, fun add_global_parameter/2),


### PR DESCRIPTION
## Proposed Changes

Add ha-promote-on-shutdown to policy definition fields for better visibility.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #556)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #556.
[#155629575]