### PR TITLE
Only try to set permissions for existing internal users

### DIFF
--- a/src/rabbit_mgmt_wm_vhost.erl
+++ b/src/rabbit_mgmt_wm_vhost.erl
@@ -103,5 +103,11 @@ put_vhost(Name, Trace, Username) ->
 maybe_grant_full_permissions(_Name, ?INTERNAL_USER) ->
     ok;
 maybe_grant_full_permissions(Name, Username) ->
+    U = rabbit_auth_backend_internal:lookup_user(Username),
+    maybe_grant_full_permissions(U, Name, Username).
+
+maybe_grant_full_permissions({ok, _}, Name, Username) ->
     rabbit_auth_backend_internal:set_permissions(
-      Username, Name, <<".*">>, <<".*">>, <<".*">>, Username).
+      Username, Name, <<".*">>, <<".*">>, <<".*">>, Username);
+maybe_grant_full_permissions(_, _Name, _Username) ->
+    ok.


### PR DESCRIPTION
Fixes #531

If the user is authenticated via LDAP but does not exist in the local db, `rabbit_auth_backend_internal:set_permissions` will throw an error that is caught by Cowboy, resulting in a 400 status code