### PR TITLE
Use hex instead of colour name in abbr warnings

### DIFF
--- a/priv/www/css/main.css
+++ b/priv/www/css/main.css
@@ -325,7 +325,7 @@ abbr { background: #99EBFF; padding: 2px 4px; border-radius: 5px; -moz-border-ra
 
 table.list td abbr a { display: inline; width: auto; }
 
-abbr.warning { background: #red; }
+abbr.warning { background: #ff7a79; }
 
 .status-red abbr, .status-yellow abbr, .status-green abbr, .status-grey abbr, small abbr, abbr.normal { background: none; color: inherit; padding: 0; border-bottom: 1px dotted; cursor: default; }
 

--- a/priv/www/css/main.css
+++ b/priv/www/css/main.css
@@ -325,7 +325,7 @@ abbr { background: #99EBFF; padding: 2px 4px; border-radius: 5px; -moz-border-ra
 
 table.list td abbr a { display: inline; width: auto; }
 
-abbr.warning { background: #ff7a79; }
+abbr.warning { background: red; }
 
 .status-red abbr, .status-yellow abbr, .status-green abbr, .status-grey abbr, small abbr, abbr.normal { background: none; color: inherit; padding: 0; border-bottom: 1px dotted; cursor: default; }
 


### PR DESCRIPTION
The colour red doesn't seem to be recognised, mirrored nodes out of sync were shown in blue

## Proposed Changes
Use hex code, using the same colour than the 'Node not running' warning.

## Types of Changes

- [ x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x ] I have read the `CONTRIBUTING.md` document
- [x ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
