### PR TITLE
`rabbitmqadmin get` doesn't provide a way to specify the `requeue` parameter required by HTTP API in 3.7.x

### DIFF
--- a/bin/rabbitmqadmin
+++ b/bin/rabbitmqadmin
@@ -161,6 +161,7 @@ EXTRA_VERBS = {
                 'uri':       '/exchanges/{vhost}/{exchange}/publish'},
     'get':     {'mandatory': ['queue'],
                 'optional':  {'count': '1', 'ackmode': 'ack_requeue_true',
+                              'requeue': 'true',
                               'payload_file': None, 'encoding': 'auto'},
                 'uri':       '/queues/{vhost}/{queue}/get'}
 }


### PR DESCRIPTION
## Proposed Changes

We can't specify the requeue argument, and when we don't specify, rabbitmqadmin refuses it.

```
# $RMQADM get queue=blabla
*** {u'key_missing': u'requeue'}
# $RMQADM get queue=blabla requeue=true

ERROR: Argument "requeue" not recognised

rabbitmqadmin --help for help
```

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

First time contributor, sorry if it's not perfect.