### PR TITLE
Make vhost creation await supervsion tree startup on all nodes

### DIFF
--- a/src/rabbit_mgmt_wm_vhost.erl
+++ b/src/rabbit_mgmt_wm_vhost.erl
@@ -92,7 +92,7 @@ id(ReqData) ->
     rabbit_mgmt_util:id(vhost, ReqData).
 
 put_vhost(Name, Trace, Username) ->
-    case rabbit_vhost:exists(Name) of
+    AddVHostResult = case rabbit_vhost:exists(Name) of
         true  -> ok;
         false -> rabbit_vhost:add(Name, Username),
                  %% wait for up to 15 seconds for the vhost to initialise
@@ -108,7 +108,8 @@ put_vhost(Name, Trace, Username) ->
         true      -> rabbit_trace:start(Name);
         false     -> rabbit_trace:stop(Name);
         undefined -> ok
-    end.
+    end,
+    AddVHostResult.
 
 %% when definitions are loaded on boot, Username here will be ?INTERNAL_USER,
 %% which does not actually exist

--- a/src/rabbit_mgmt_wm_vhost.erl
+++ b/src/rabbit_mgmt_wm_vhost.erl
@@ -65,7 +65,7 @@ accept_content(ReqData0, Context = #context{user = #user{username = Username}}) 
       fun(_, VHost, ReqData) ->
               Trace = rabbit_mgmt_util:parse_bool(maps:get(tracing, VHost, undefined)),
               case put_vhost(Name, Trace, Username) of
-                  ok               ->
+                  ok                   ->
                       {true, ReqData, Context};
                   {error, timeout} = E ->
                       rabbit_mgmt_util:internal_server_error(
@@ -99,15 +99,15 @@ put_vhost(Name, Trace, Username) ->
                  %% on all nodes
                  case rabbit_vhost:await_running_on_all_nodes(Name, 15000) of
                      ok               ->
-                         maybe_grant_full_permissions(Name, Username),
-                         case Trace of
-                             true      -> rabbit_trace:start(Name);
-                             false     -> rabbit_trace:stop(Name);
-                             undefined -> ok
-                         end;
+                         maybe_grant_full_permissions(Name, Username);
                      {error, timeout} ->
                          {error, timeout}
                  end
+    end,
+    case Trace of
+        true      -> rabbit_trace:start(Name);
+        false     -> rabbit_trace:stop(Name);
+        undefined -> ok
     end.
 
 %% when definitions are loaded on boot, Username here will be ?INTERNAL_USER,

--- a/src/rabbit_mgmt_wm_vhost.erl
+++ b/src/rabbit_mgmt_wm_vhost.erl
@@ -63,10 +63,15 @@ accept_content(ReqData0, Context = #context{user = #user{username = Username}}) 
     rabbit_mgmt_util:with_decode(
       [], ReqData0, Context,
       fun(_, VHost, ReqData) ->
-              put_vhost(Name, rabbit_mgmt_util:parse_bool(
-                                maps:get(tracing, VHost, undefined)),
-                        Username),
-              {true, ReqData, Context}
+              Trace = rabbit_mgmt_util:parse_bool(maps:get(tracing, VHost, undefined)),
+              case put_vhost(Name, Trace, Username) of
+                  ok               ->
+                      {true, ReqData, Context};
+                  {error, timeout} = E ->
+                      rabbit_mgmt_util:internal_server_error(
+                        "Timed out while waiting for the vhost to initialise", E,
+                        ReqData0, Context)
+              end
       end).
 
 delete_resource(ReqData, Context = #context{user = #user{username = Username}}) ->
@@ -90,12 +95,19 @@ put_vhost(Name, Trace, Username) ->
     case rabbit_vhost:exists(Name) of
         true  -> ok;
         false -> rabbit_vhost:add(Name, Username),
-                 maybe_grant_full_permissions(Name, Username)
-    end,
-    case Trace of
-        true      -> rabbit_trace:start(Name);
-        false     -> rabbit_trace:stop(Name);
-        undefined -> ok
+                 %% wait for up to 15 seconds for the vhost to initialise
+                 %% on all nodes
+                 case rabbit_vhost:await_running_on_all_nodes(Name, 15000) of
+                     ok               ->
+                         maybe_grant_full_permissions(Name, Username),
+                         case Trace of
+                             true      -> rabbit_trace:start(Name);
+                             false     -> rabbit_trace:stop(Name);
+                             undefined -> ok
+                         end;
+                     {error, timeout} ->
+                         {error, timeout}
+                 end
     end.
 
 %% when definitions are loaded on boot, Username here will be ?INTERNAL_USER,

--- a/src/rabbit_mgmt_wm_vhost.erl
+++ b/src/rabbit_mgmt_wm_vhost.erl
@@ -92,7 +92,7 @@ id(ReqData) ->
     rabbit_mgmt_util:id(vhost, ReqData).
 
 put_vhost(Name, Trace, Username) ->
-    AddVHostResult = case rabbit_vhost:exists(Name) of
+    Result = case rabbit_vhost:exists(Name) of
         true  -> ok;
         false -> rabbit_vhost:add(Name, Username),
                  %% wait for up to 15 seconds for the vhost to initialise
@@ -109,7 +109,7 @@ put_vhost(Name, Trace, Username) ->
         false     -> rabbit_trace:stop(Name);
         undefined -> ok
     end,
-    AddVHostResult.
+    Result.
 
 %% when definitions are loaded on boot, Username here will be ?INTERNAL_USER,
 %% which does not actually exist


### PR DESCRIPTION
## Proposed Changes

This makes the vhost creation API endpoint to waits until tje vhost's supervision tree is up on all nodes. See rabbitmq/rabbitmq-management#575 for details.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #575)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Part of #575.

[#157817330]