### PR TITLE
Make sure listener has a port even if it's not provided in the config

### DIFF
--- a/src/rabbit_mgmt_app.erl
+++ b/src/rabbit_mgmt_app.erl
@@ -44,9 +44,13 @@ reset_dispatcher(IgnoreApps) ->
     {ok, Listener} = application:get_env(rabbitmq_management, listener),
     register_context(Listener, IgnoreApps).
 
-register_context(Listener, IgnoreApps) ->
+register_context(Listener0, IgnoreApps) ->
+    M0 = maps:from_list(Listener0),
+    %% include default port if it's not provided in the config
+    %% as Cowboy won't start if the port is missing
+    M1 = maps:merge(#{port => 15672}, M0),
     rabbit_web_dispatch:register_context_handler(
-      ?CONTEXT, Listener, "",
+      ?CONTEXT, maps:to_list(M1), "",
       rabbit_mgmt_dispatcher:build_dispatcher(IgnoreApps),
       "RabbitMQ Management").
 


### PR DESCRIPTION
## Proposed Changes

This makes sure the listener always has a port specified, even if it's missing from the config file.

## Types of Changes

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Discovered while QA'ing #596, even though they are not strictly related.

[#159556318]
