### PR TITLE
Use absolute link for rabbitmqadmin

### DIFF
--- a/priv/www/cli/index.html
+++ b/priv/www/cli/index.html
@@ -21,7 +21,7 @@
     </p>
 
     <p>
-      To use it, <a href="rabbitmqadmin">download it</a> from this node (right click,
+      To use it, <a href="/cli/rabbitmqadmin">download it</a> from this node (right click,
       Save As), make sure it is executable, and drop it in your <code>PATH</code>. Note that
       many browsers will rename the
       file <code>rabbitmqadmin.txt</code>. <code>rabbitmqadmin</code> requires Python


### PR DESCRIPTION
## Proposed Changes

If a user is browsing the cli page via e.g. http://localhost:15672/cli,
the link will become http://localhost:15672/rabbitmqadmin since there is
no `/` after `/cli`. If a user is browsing the cli page via e.g.
`http://localhost:15672/cli/ the link will become
http://localhost:15672/cli/rabbitmqadmin and it will work as expected.

The easiest fix was to use an absolute link instead and not depend on
the final `/`.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the mailing list. We're here to help! This is simply a reminder
of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ x I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the
discussion by explaining why you chose the solution you did and what
alternatives you considered, etc.
