### PR TITLE
Add basic.get_empty stats as a new counter

### DIFF
--- a/priv/www/js/charts.js
+++ b/priv/www/js/charts.js
@@ -13,6 +13,7 @@ function message_rates(id, stats) {
                  ['Redelivered', 'redeliver'],
                  ['Get (manual ack)', 'get'],
                  ['Get (auto ack)', 'get_no_ack'],
+                 ['Get (empty)', 'get_empty'],
                  ['Return', 'return_unroutable'],
                  ['Disk read', 'disk_reads'],
                  ['Disk write', 'disk_writes']];

--- a/priv/www/js/global.js
+++ b/priv/www/js/global.js
@@ -372,6 +372,8 @@ var HELP = {
         <dd>Rate at which messages requiring acknowledgement are being delivered in response to basic.get.</dd>\
         <dt>Get (auto ack)</dt>\
         <dd>Rate at which messages not requiring acknowledgement are being delivered in response to basic.get.</dd>\
+        <dt>Get (empty)</dt>\
+        <dd>Rate at which empty queues are hit in response to basic.get.</dd>\
         <dt>Return</dt>\
         <dd>Rate at which basic.return is sent to publishers for unroutable messages published with the \'mandatory\' flag set.</dd>\
         <dt>Disk read</dt>\

--- a/src/rabbit_mgmt_stats.erl
+++ b/src/rabbit_mgmt_stats.erl
@@ -115,14 +115,14 @@ append_full_sample(TS, {V1, V2, V3}, {S1, S2, S3}, {T1, T2, T3}) ->
      {V1 + T1, V2 + T2, V3 + T3}};
 %% channel_queue_stats_deliver_stats, queue_stats_deliver_stats,
 %% vhost_stats_deliver_stats, channel_stats_deliver_stats
-append_full_sample(TS, {V1, V2, V3, V4, V5, V6, V7},
-           {S1, S2, S3, S4, S5, S6, S7},
-           {T1, T2, T3, T4, T5, T6, T7}) ->
+append_full_sample(TS, {V1, V2, V3, V4, V5, V6, V7, V8},
+           {S1, S2, S3, S4, S5, S6, S7, S8},
+           {T1, T2, T3, T4, T5, T6, T7, T8}) ->
     {{append_sample(V1, TS, S1), append_sample(V2, TS, S2),
       append_sample(V3, TS, S3), append_sample(V4, TS, S4),
       append_sample(V5, TS, S5), append_sample(V6, TS, S6),
-      append_sample(V7, TS, S7)},
-     {V1 + T1, V2 + T2, V3 + T3, V4 + T4, V5 + T5, V6 + T6, V7 + T7}};
+      append_sample(V7, TS, S7), append_sample(V8, TS, S8)},
+     {V1 + T1, V2 + T2, V3 + T3, V4 + T4, V5 + T5, V6 + T6, V7 + T7, V8 + T8}};
 %% channel_process_stats, queue_stats_publish, queue_exchange_stats_publish,
 %% exchange_stats_publish_out, exchange_stats_publish_in, queue_process_stats
 append_full_sample(TS, {V1}, {S1}, {T1}) ->
@@ -200,8 +200,8 @@ format_rate(Type, {TP, TC, TRe}, {RP, RC, RRe})
      {return_unroutable, TRe},
      {return_unroutable_details, [{rate, RRe}]}
     ];
-format_rate(Type, {TG, TGN, TD, TDN, TR, TA, TDG},
-        {RG, RGN, RD, RDN, RR, RA, RDG})
+format_rate(Type, {TG, TGN, TD, TDN, TR, TA, TDG, TGE},
+        {RG, RGN, RD, RDN, RR, RA, RDG, RGE})
   when Type =:= channel_queue_stats_deliver_stats;
        Type =:= channel_stats_deliver_stats;
        Type =:= vhost_stats_deliver_stats;
@@ -220,7 +220,9 @@ format_rate(Type, {TG, TGN, TD, TDN, TR, TA, TDG},
      {ack, TA},
      {ack_details, [{rate, RA}]},
      {deliver_get, TDG},
-     {deliver_get_details, [{rate, RDG}]}
+     {deliver_get_details, [{rate, RDG}]},
+     {get_empty, TGE},
+     {get_empty_details, [{rate, RGE}]}
     ];
 format_rate(Type, {TR}, {RR}) when Type =:= channel_process_stats;
                    Type =:= queue_process_stats ->
@@ -386,8 +388,10 @@ format_rate(Type, {TP, TC, TRe}, {RP, RC, RRe},
      {return_unroutable_details, [{rate, RRe},
                   {samples, SRe}] ++ average(SRe, STRe, Length)}
     ];
-format_rate(Type, {TG, TGN, TD, TDN, TR, TA, TDG}, {RG, RGN, RD, RDN, RR, RA, RDG},
-        {SG, SGN, SD, SDN, SR, SA, SDG}, {STG, STGN, STD, STDN, STR, STA, STDG},
+format_rate(Type, {TG, TGN, TD, TDN, TR, TA, TDG, TGE},
+            {RG, RGN, RD, RDN, RR, RA, RDG, RGE},
+            {SG, SGN, SD, SDN, SR, SA, SDG, SGE},
+            {STG, STGN, STD, STDN, STR, STA, STDG, STGE},
         Length)
   when Type =:= channel_queue_stats_deliver_stats;
        Type =:= channel_stats_deliver_stats;
@@ -414,7 +418,10 @@ format_rate(Type, {TG, TGN, TD, TDN, TR, TA, TDG}, {RG, RGN, RD, RDN, RR, RA, RD
             {samples, SA}] ++ average(SA, STA, Length)},
      {deliver_get, TDG},
      {deliver_get_details, [{rate, RDG},
-                {samples, SDG}] ++ average(SDG, STDG, Length)}
+                {samples, SDG}] ++ average(SDG, STDG, Length)},
+     {get_empty, TGE},
+     {get_empty_details, [{rate, RGE},
+                          {samples, SGE}] ++ average(SGE, STGE, Length)}
     ];
 format_rate(Type, {TR}, {RR}, {SR}, {STR}, Length)
   when Type =:= channel_process_stats;


### PR DESCRIPTION
Basic.get requests that returned `ok_empty` used to be unaccounted for

## Types of Changes
- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the
discussion by explaining why you chose the solution you did and what
alternatives you considered, etc.
