### PR TITLE
Ensure that login success clears a warn popup

### DIFF
--- a/priv/www/js/main.js
+++ b/priv/www/js/main.js
@@ -85,6 +85,7 @@ function check_login() {
         replace_content('login-status', '<p>Login failed</p>');
     }
     else {
+        hide_popup_warn();
         replace_content('outer', format('layout', {}));
         var user_login_session_timeout = parseInt(user.login_session_timeout);
         // Update auth login_session_timeout if changed
@@ -530,6 +531,14 @@ function show_popup(type, text, _mode) {
     $(cssClass + ' span').click(function () {
         $('.popup-owner').removeClass('popup-owner');
         hide();
+    });
+}
+
+function hide_popup_warn() {
+    var cssClass = '.form-popup-warn';
+    $('.popup-owner').removeClass('popup-owner');
+    $(cssClass).fadeOut(100, function() {
+        $(this).remove();
     });
 }
 


### PR DESCRIPTION
If you enter invalid credentials and attempt login, you will see the warning popup show. Then, do not close it but log in with valid credentials. The popup remains. You can close it via the "Close" button but this change will remove the popup for you

Fixes #609, reported in rabbitmq/rabbitmq-server#1704