### PR TITLE
Make it possible to configure TCP and TLS listeners at the same time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ PROJECT_MOD = rabbit_mgmt_app
 
 define PROJECT_ENV
 [
-	    {listener,          [{port, 15672}]},
 	    {http_log_dir,      none},
 	    {load_definitions,  none},
 	    {management_db_cache_multiplier, 5},

--- a/priv/schema/rabbitmq_management.schema
+++ b/priv/schema/rabbitmq_management.schema
@@ -51,8 +51,6 @@
     [{datatype, integer}]}.
 {mapping, "management.ssl.ip", "rabbitmq_management.ssl_config.ip",
     [{datatype, string}, {validators, ["is_ip"]}]}.
-{mapping, "management.ssl.listener", "rabbitmq_management.ssl_config",
-    [{datatype, ip}]}.
 {mapping, "management.ssl.certfile", "rabbitmq_management.ssl_config.certfile",
     [{datatype, string}, {validators, ["file_accessible"]}]}.
 {mapping, "management.ssl.keyfile", "rabbitmq_management.ssl_config.keyfile",

--- a/priv/schema/rabbitmq_management.schema
+++ b/priv/schema/rabbitmq_management.schema
@@ -20,10 +20,52 @@
 {mapping, "management.http_log_dir", "rabbitmq_management.http_log_dir",
     [{datatype, string}]}.
 
+%% HTTP (TCP) listener options ========================================================
 
-%% Change the port on which the HTTP listener listens,
-%% specifying an interface for the web server to bind to.
-%% Also set the listener to use SSL and provide SSL options.
+%% HTTP listener consistent with Web STOMP and Web MQTT.
+%%
+%% {tcp_config, [{port,     15672},
+%%               {ip,       "127.0.0.1"}]}
+
+{mapping, "management.tcp.port", "rabbitmq_management.tcp_config.port",
+    [{datatype, integer}]}.
+
+{mapping, "management.tcp.ip", "rabbitmq_management.tcp_config.ip",
+    [{datatype, string},
+     {validators, ["is_ip"]}]}.
+
+
+%% HTTPS (TLS) listener options ========================================================
+
+%% HTTPS listener consistent with Web STOMP and Web MQTT.
+%%
+%% {ssl_config, [{port,       15671},
+%%               {ip,         "127.0.0.1"},
+%%               {cacertfile, "/path/to/cacert.pem"},
+%%               {certfile,   "/path/to/cert.pem"},
+%%               {keyfile,    "/path/to/key.pem"}]}
+
+{mapping, "management.ssl.port", "rabbitmq_management.ssl_config.port",
+    [{datatype, integer}]}.
+{mapping, "management.ssl.backlog", "rabbitmq_management.ssl_config.backlog",
+    [{datatype, integer}]}.
+{mapping, "management.ssl.ip", "rabbitmq_management.ssl_config.ip",
+    [{datatype, string}, {validators, ["is_ip"]}]}.
+{mapping, "management.ssl.listener", "rabbitmq_management.ssl_config",
+    [{datatype, ip}]}.
+{mapping, "management.ssl.certfile", "rabbitmq_management.ssl_config.certfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+{mapping, "management.ssl.keyfile", "rabbitmq_management.ssl_config.keyfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+{mapping, "management.ssl.cacertfile", "rabbitmq_management.ssl_config.cacertfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+{mapping, "management.ssl.password", "rabbitmq_management.ssl_config.password",
+    [{datatype, string}]}.
+
+
+%% Legacy listener options ========================================================
+
+%% Legacy (pre-3.7.9) TCP listener format.
 %%
 %% {listener, [{port,     12345},
 %%             {ip,       "127.0.0.1"},
@@ -41,8 +83,6 @@
 
 {mapping, "management.listener.ssl", "rabbitmq_management.listener.ssl",
     [{datatype, {enum, [true, false]}}]}.
-
-%% Cowboy (HTTP server) options ========================================================
 
 {mapping, "management.listener.server.compress", "rabbitmq_management.listener.cowboy_opts.compress",
     [{datatype, {enum, [true, false]}}]}.
@@ -62,7 +102,7 @@
 {mapping, "management.listener.server.max_keepalive", "rabbitmq_management.listener.cowboy_opts.max_keepalive",
     [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
 
-%% HTTPS (TLS) options ========================================================
+%% Legacy HTTPS listener options ========================================================
 
 {mapping, "management.listener.ssl_opts", "rabbitmq_management.listener.ssl_opts", [
     {datatype, {enum, [none]}}

--- a/src/rabbit_mgmt_app.erl
+++ b/src/rabbit_mgmt_app.erl
@@ -26,9 +26,9 @@
 -define(DEFAULT_PORT, 15672).
 
 start(_Type, _StartArgs) ->
-    %% Modern TCP listener: configured vi management.tcp.*.
-    %% Legacy TCP listener: legacy management.listener.*.
-    %% TLS listener: configured via management.ssl.*
+    %% Modern TCP listener uses management.tcp.*.
+    %% Legacy TCP (or TLS) listener uses management.listener.*.
+    %% Modern TLS listener uses management.ssl.*
     case {has_configured_legacy_listener(),
           has_configured_tcp_listener(),
           has_configured_tls_listener()} of

--- a/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -8,27 +8,75 @@
        [{http_log_dir,"test/config_schema_SUITE_data/rabbit-mgmt"},
         {rates_mode,basic}]}],
   [rabbitmq_management]},
- {listener_port,
-  "management.listener.port = 12345",
-  [{rabbitmq_management,[{listener,[{port,12345}]}]}],
+
+ %%
+ %% TCP listener
+ %%
+
+ {tcp_listener_port_only,
+  "management.tcp.port = 15674",
+  [{rabbitmq_management,[
+                         {tcp_config,[
+                                      {port,15674}
+                                     ]}
+                        ]}],
   [rabbitmq_management]},
- {ssl,
-  "management.listener.port = 15671
-   management.listener.ssl = true
-   management.listener.ssl_opts.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
-   management.listener.ssl_opts.certfile = test/config_schema_SUITE_data/certs/cert.pem
-   management.listener.ssl_opts.keyfile = test/config_schema_SUITE_data/certs/key.pem",
-  [{rabbitmq_management,
-       [{listener,
-            [{port,15671},
-             {ssl,true},
-             {ssl_opts,
-                 [{cacertfile,
-                      "test/config_schema_SUITE_data/certs/cacert.pem"},
-                  {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
-                  {keyfile,
-                      "test/config_schema_SUITE_data/certs/key.pem"}]}]}]}],
+
+ {tcp_listener_interface_port,
+  "management.tcp.ip   = 192.168.1.2
+   management.tcp.port = 15674",
+  [{rabbitmq_management,[
+                         {tcp_config,[
+                                      {ip, "192.168.1.2"},
+                                      {port,15674}
+                                     ]}
+                        ]}],
   [rabbitmq_management]},
+
+
+ %%
+ %% TLS listener
+ %%
+
+ {tls_listener_port_only,
+  "management.ssl.port = 15671",
+  [{rabbitmq_management,[
+                         {ssl_config,[
+                                      {port,15671}
+                                     ]}
+                        ]}],
+  [rabbitmq_management]},
+
+ {tls_listener_interface_port,
+  "management.ssl.ip   = 192.168.1.2
+   management.ssl.port = 15671",
+  [{rabbitmq_management,[
+                         {ssl_config,[
+                                      {ip, "192.168.1.2"},
+                                      {port,15671}
+                                     ]}
+                        ]}],
+  [rabbitmq_management]},
+
+ {tls_listener,
+  "management.ssl.ip   = 192.168.1.2
+   management.ssl.port = 15671
+   management.ssl.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+   management.ssl.certfile = test/config_schema_SUITE_data/certs/cert.pem
+   management.ssl.keyfile = test/config_schema_SUITE_data/certs/key.pem",
+  [{rabbitmq_management,[
+                         {ssl_config,[
+                                      {ip, "192.168.1.2"},
+                                      {port,15671},
+                                      {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
+                                      {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+                                      {keyfile,"test/config_schema_SUITE_data/certs/key.pem"}
+                                     ]}
+                        ]}],
+  [rabbitmq_management]},
+
+
+
  {retention_policies,
   "management.sample_retention_policies.global.minute  = 5
    management.sample_retention_policies.global.hour    = 60
@@ -43,29 +91,6 @@
             [{global,[{60,5},{3600,60},{86400,1200}]},
              {basic,[{60,5},{3600,60}]},
              {detailed,[{10,5}]}]}]}],
-  [rabbitmq_management]},
- {listener_ip,
-  "management.listener.port = 15672
-   management.listener.ip   = 127.0.0.1",
-  [{rabbitmq_management,[{listener,[{port,15672},{ip,"127.0.0.1"}]}]}],
-  [rabbitmq_management]},
- {ssl_port,
-  "management.listener.port = 15672
-   management.listener.ssl  = true
-
-   management.listener.ssl_opts.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
-   management.listener.ssl_opts.certfile   = test/config_schema_SUITE_data/certs/cert.pem
-   management.listener.ssl_opts.keyfile    = test/config_schema_SUITE_data/certs/key.pem",
-  [{rabbitmq_management,
-       [{listener,
-            [{port,15672},
-             {ssl,true},
-             {ssl_opts,
-                 [{cacertfile,
-                      "test/config_schema_SUITE_data/certs/cacert.pem"},
-                  {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
-                  {keyfile,
-                      "test/config_schema_SUITE_data/certs/key.pem"}]}]}]}],
   [rabbitmq_management]},
 
  {path_prefix,
@@ -109,7 +134,59 @@
   ], [rabbitmq_management]
  },
 
- {server_opts_compress,
+
+ %%
+ %% Legacy listener configuration
+ %%
+
+ {legacy_tcp_listener,
+  "management.listener.port = 12345",
+  [{rabbitmq_management,[{listener,[{port,12345}]}]}],
+  [rabbitmq_management]},
+
+ {legacy_ssl_listener,
+  "management.listener.port = 15671
+   management.listener.ssl = true
+   management.listener.ssl_opts.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+   management.listener.ssl_opts.certfile = test/config_schema_SUITE_data/certs/cert.pem
+   management.listener.ssl_opts.keyfile = test/config_schema_SUITE_data/certs/key.pem",
+  [{rabbitmq_management,
+       [{listener,
+            [{port,15671},
+             {ssl,true},
+             {ssl_opts,
+                 [{cacertfile,
+                      "test/config_schema_SUITE_data/certs/cacert.pem"},
+                  {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+                  {keyfile,
+                      "test/config_schema_SUITE_data/certs/key.pem"}]}]}]}],
+  [rabbitmq_management]},
+
+ {legacy_tcp_listener_ip,
+  "management.listener.port = 15672
+   management.listener.ip   = 127.0.0.1",
+  [{rabbitmq_management,[{listener,[{port,15672},{ip,"127.0.0.1"}]}]}],
+  [rabbitmq_management]},
+ {legacy_ssl_listener_port,
+  "management.listener.port = 15672
+   management.listener.ssl  = true
+
+   management.listener.ssl_opts.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+   management.listener.ssl_opts.certfile   = test/config_schema_SUITE_data/certs/cert.pem
+   management.listener.ssl_opts.keyfile    = test/config_schema_SUITE_data/certs/key.pem",
+  [{rabbitmq_management,
+       [{listener,
+            [{port,15672},
+             {ssl,true},
+             {ssl_opts,
+                 [{cacertfile,
+                      "test/config_schema_SUITE_data/certs/cacert.pem"},
+                  {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+                  {keyfile,
+                      "test/config_schema_SUITE_data/certs/key.pem"}]}]}]}],
+  [rabbitmq_management]},
+
+ {legacy_server_opts_compress,
   "management.listener.server.compress = true",
   [
    {rabbitmq_management, [
@@ -118,7 +195,7 @@
   ], [rabbitmq_management]
  },
 
- {server_opts_compress_and_idle_timeout,
+ {legacy_server_opts_compress_and_idle_timeout,
   "management.listener.server.compress     = true
    management.listener.server.idle_timeout = 123",
   [
@@ -129,7 +206,7 @@
   ], [rabbitmq_management]
  },
 
- {server_opts_compress_and_multiple_timeouts,
+ {legacy_server_opts_compress_and_multiple_timeouts,
   "management.listener.server.compress     = true
    management.listener.server.idle_timeout = 123
    management.listener.server.inactivity_timeout = 456
@@ -144,7 +221,7 @@
   ], [rabbitmq_management]
  },
 
- {server_opts_multiple_timeouts_only,
+ {legacy_server_opts_multiple_timeouts_only,
   "management.listener.server.idle_timeout = 123
    management.listener.server.inactivity_timeout = 456
    management.listener.server.request_timeout = 789",
@@ -157,7 +234,7 @@
   ], [rabbitmq_management]
  },
 
- {server_opts_shutdown_timeout,
+ {legacy_server_opts_shutdown_timeout,
   "management.listener.server.shutdown_timeout = 7000",
   [
    {rabbitmq_management, [
@@ -166,7 +243,7 @@
   ], [rabbitmq_management]
  },
 
- {server_opts_max_keepalive,
+ {legacy_server_opts_max_keepalive,
   "management.listener.server.max_keepalive = 120",
   [
    {rabbitmq_management, [
@@ -174,4 +251,5 @@
                          ]}
   ], [rabbitmq_management]
  }
+
 ].


### PR DESCRIPTION
## Proposed Changes

This introduces new Cuttlefish schema settings for TCP and TLS listeners, à la Web STOMP and Web MQTT. The existing (now legacy) config settings are still supported.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #563)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #563.

[#156776853]