### PR TITLE
Support advanced Cowboy options via management.{tcp,ssl}.*

### DIFF
--- a/priv/schema/rabbitmq_management.schema
+++ b/priv/schema/rabbitmq_management.schema
@@ -29,10 +29,22 @@
 
 {mapping, "management.tcp.port", "rabbitmq_management.tcp_config.port",
     [{datatype, integer}]}.
-
 {mapping, "management.tcp.ip", "rabbitmq_management.tcp_config.ip",
     [{datatype, string},
      {validators, ["is_ip"]}]}.
+
+{mapping, "management.tcp.compress", "rabbitmq_management.tcp_config.cowboy_opts.compress",
+    [{datatype, {enum, [true, false]}}]}.
+{mapping, "management.tcp.idle_timeout", "rabbitmq_management.tcp_config.cowboy_opts.idle_timeout",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
+{mapping, "management.tcp.inactivity_timeout", "rabbitmq_management.tcp_config.cowboy_opts.inactivity_timeout",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
+{mapping, "management.tcp.request_timeout", "rabbitmq_management.tcp_config.cowboy_opts.request_timeout",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
+{mapping, "management.tcp.shutdown_timeout", "rabbitmq_management.tcp_config.cowboy_opts.shutdown_timeout",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
+{mapping, "management.tcp.max_keepalive", "rabbitmq_management.tcp_config.cowboy_opts.max_keepalive",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
 
 
 %% HTTPS (TLS) listener options ========================================================
@@ -59,6 +71,20 @@
     [{datatype, string}, {validators, ["file_accessible"]}]}.
 {mapping, "management.ssl.password", "rabbitmq_management.ssl_config.password",
     [{datatype, string}]}.
+
+{mapping, "management.ssl.compress", "rabbitmq_management.ssl_config.cowboy_opts.compress",
+    [{datatype, {enum, [true, false]}}]}.
+{mapping, "management.ssl.idle_timeout", "rabbitmq_management.ssl_config.cowboy_opts.idle_timeout",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
+{mapping, "management.ssl.inactivity_timeout", "rabbitmq_management.ssl_config.cowboy_opts.inactivity_timeout",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
+{mapping, "management.ssl.request_timeout", "rabbitmq_management.ssl_config.cowboy_opts.request_timeout",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
+{mapping, "management.ssl.shutdown_timeout", "rabbitmq_management.ssl_config.cowboy_opts.shutdown_timeout",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
+{mapping, "management.ssl.max_keepalive", "rabbitmq_management.ssl_config.cowboy_opts.max_keepalive",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
+
 
 
 %% Legacy listener options ========================================================

--- a/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -33,6 +33,72 @@
                         ]}],
   [rabbitmq_management]},
 
+ {tcp_listener_server_opts_compress,
+  "management.tcp.compress = true",
+  [
+   {rabbitmq_management, [
+                          {tcp_config, [{cowboy_opts, [{compress, true}]}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {tcp_listener_server_opts_compress_and_idle_timeout,
+  "management.tcp.compress     = true
+   management.tcp.idle_timeout = 123",
+  [
+   {rabbitmq_management, [
+                          {tcp_config, [{cowboy_opts, [{compress,     true},
+                                                     {idle_timeout, 123}]}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {tcp_listener_server_opts_compress_and_multiple_timeouts,
+  "management.tcp.compress     = true
+   management.tcp.idle_timeout = 123
+   management.tcp.inactivity_timeout = 456
+   management.tcp.request_timeout = 789",
+  [
+   {rabbitmq_management, [
+                          {tcp_config, [{cowboy_opts, [{compress,           true},
+                                                     {idle_timeout,       123},
+                                                     {inactivity_timeout, 456},
+                                                     {request_timeout,    789}]}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {tcp_listener_server_opts_multiple_timeouts_only,
+  "management.tcp.idle_timeout = 123
+   management.tcp.inactivity_timeout = 456
+   management.tcp.request_timeout = 789",
+  [
+   {rabbitmq_management, [
+                          {tcp_config, [{cowboy_opts, [{idle_timeout,       123},
+                                                     {inactivity_timeout, 456},
+                                                     {request_timeout,    789}]}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {tcp_listener_server_opts_shutdown_timeout,
+  "management.tcp.shutdown_timeout = 7000",
+  [
+   {rabbitmq_management, [
+                          {tcp_config, [{cowboy_opts, [{shutdown_timeout, 7000}]}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {tcp_listener_server_opts_max_keepalive,
+  "management.tcp.max_keepalive = 120",
+  [
+   {rabbitmq_management, [
+                          {tcp_config, [{cowboy_opts, [{max_keepalive, 120}]}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
 
  %%
  %% TLS listener
@@ -75,7 +141,75 @@
                         ]}],
   [rabbitmq_management]},
 
+ {tls_listener_server_opts_compress,
+  "management.ssl.compress = true",
+  [
+   {rabbitmq_management, [
+                          {ssl_config, [{cowboy_opts, [{compress, true}]}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
 
+ {tls_listener_server_opts_compress_and_idle_timeout,
+  "management.ssl.compress     = true
+   management.ssl.idle_timeout = 123",
+  [
+   {rabbitmq_management, [
+                          {ssl_config, [{cowboy_opts, [{compress,     true},
+                                                       {idle_timeout, 123}]}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {tls_listener_server_opts_compress_and_multiple_timeouts,
+  "management.ssl.compress     = true
+   management.ssl.idle_timeout = 123
+   management.ssl.inactivity_timeout = 456
+   management.ssl.request_timeout = 789",
+  [
+   {rabbitmq_management, [
+                          {ssl_config, [{cowboy_opts, [{compress,           true},
+                                                       {idle_timeout,       123},
+                                                       {inactivity_timeout, 456},
+                                                       {request_timeout,    789}]}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {tls_listener_server_opts_multiple_timeouts_only,
+  "management.ssl.idle_timeout = 123
+   management.ssl.inactivity_timeout = 456
+   management.ssl.request_timeout = 789",
+  [
+   {rabbitmq_management, [
+                          {ssl_config, [{cowboy_opts, [{idle_timeout,       123},
+                                                       {inactivity_timeout, 456},
+                                                       {request_timeout,    789}]}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {tls_listener_server_opts_shutdown_timeout,
+  "management.ssl.shutdown_timeout = 7000",
+  [
+   {rabbitmq_management, [
+                          {ssl_config, [{cowboy_opts, [{shutdown_timeout, 7000}]}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {tls_listener_server_opts_max_keepalive,
+  "management.ssl.max_keepalive = 120",
+  [
+   {rabbitmq_management, [
+                          {ssl_config, [{cowboy_opts, [{max_keepalive, 120}]}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ %%
+ %% Retention Policies
+ %%
 
  {retention_policies,
   "management.sample_retention_policies.global.minute  = 5
@@ -110,6 +244,10 @@
                          ]}
   ], [rabbitmq_management]
  },
+
+ %%
+ %% CORS
+ %%
 
  {cors_settings,
   "management.cors.allow_origins.1 = https://origin1.org


### PR DESCRIPTION
## Proposed Changes

This is a follow-up change to #618 that makes it possible to configure advanced Cowboy options for the new listeners.


## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue rabbitmq/rabbitmq-management#563)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

References #563.

[#156776853]

An example config file:

``` ini
management.tcp.shutdown_timeout = 70
management.tcp.max_keepalive = 120
management.tcp.idle_timeout = 120
management.tcp.inactivity_timeout = 120
management.tcp.request_timeout = 120
management.tcp.compress = true

management.ssl.port = 15671
management.ssl.cacertfile = /path/to/ca_certificate.pem
management.ssl.certfile = /path/to/server_certificate.pem
management.ssl.keyfile = /path/to/server_key.pem
management.ssl.shutdown_timeout = 70
management.ssl.max_keepalive = 120
management.ssl.idle_timeout = 120
management.ssl.inactivity_timeout = 120
management.ssl.request_timeout = 120
management.ssl.compress = true

```
