### PR TITLE
Make logo lead to /#: it works better with a path_prefix

### DIFF
--- a/priv/www/js/tmpl/layout.ejs
+++ b/priv/www/js/tmpl/layout.ejs
@@ -22,7 +22,7 @@
     </li>
   </ul>
   <div id="logo">
-    <a href="/"><img src="img/rabbitmqlogo.png" alt="RabbitMQ logo" width="204" height="37"/></a>
+    <a href="#/"><img src="img/rabbitmqlogo.png" alt="RabbitMQ logo" width="204" height="37"/></a>
     <span id="versions"></span>
   </div>
   <div id="menu">


### PR DESCRIPTION
## Proposed Changes

This makes the logo lead to `/#`: it works better when a `management.path_prefix` is used.

Taking the user to `/` with a `path_prefix` actually works just
fine if the `/` is accessiable: that will redirect to the prefixed root.
However, if `/` is not served by the HTTP API (think of a reverse proxy
in front of it mediating and controlling access), that will fail.

`/#` should not suffer from this problem. In fact, that's what the Overview tab has been using for years.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #604)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #604.

[#161479342]
