### PR TITLE
Fix context restart and use two contexts (TLS and TCP) in rabbitmq-management web dispatch.

### DIFF
--- a/src/rabbit_mgmt_app.erl
+++ b/src/rabbit_mgmt_app.erl
@@ -22,48 +22,65 @@
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").
 
--define(CONTEXT, rabbit_mgmt).
+-define(TCP_CONTEXT, rabbitmq_management_tcp).
+-define(TLS_CONTEXT, rabbitmq_management_tls).
 -define(DEFAULT_PORT, 15672).
 
 start(_Type, _StartArgs) ->
     %% Modern TCP listener uses management.tcp.*.
     %% Legacy TCP (or TLS) listener uses management.listener.*.
     %% Modern TLS listener uses management.ssl.*
-    case {has_configured_legacy_listener(),
+    start_configured_listener([], true),
+    rabbit_mgmt_sup_sup:start_link().
+
+stop(_State) ->
+    unregister_all_contexts(),
+    ok.
+
+%% At the point at which this is invoked we have both newly enabled
+%% apps and about-to-disable apps running (so that
+%% rabbit_mgmt_reset_handler can look at all of them to find
+%% extensions). Therefore we have to explicitly exclude
+%% about-to-disable apps from our new dispatcher.
+reset_dispatcher(IgnoreApps) ->
+    unregister_all_contexts(),
+    start_configured_listener(IgnoreApps, false).
+
+-spec start_configured_listener([atom()], boolean()) -> ok.
+start_configured_listener(IgnoreApps, NeedLogStartup) ->
+    Listeners = case {has_configured_legacy_listener(),
           has_configured_tcp_listener(),
           has_configured_tls_listener()} of
         {false, false, false} ->
             %% nothing is configured
-            start_tcp_listener();
+            [get_tcp_listener()];
         {false, false, true} ->
-            maybe_start_tls_listener();
+            [get_tls_listener()];
         {false, true, false} ->
-            maybe_start_tcp_listener();
+            [get_tcp_listener()];
         {false, true, true} ->
-            maybe_start_tcp_listener(),
-            maybe_start_tls_listener();
+            [get_tcp_listener(),
+             get_tls_listener()];
         {true,  false, false} ->
-            maybe_start_legacy_listener();
+            [get_legacy_listener()];
         {true,  false, true} ->
-            maybe_start_legacy_listener(),
-            maybe_start_tls_listener();
+            [get_legacy_listener(),
+             get_tls_listener()];
         {true,  true, false}  ->
             %% This combination makes some sense:
             %% legacy listener can be used to set up TLS :/
-            maybe_start_legacy_listener(),
-            maybe_start_tcp_listener();
+            [get_legacy_listener(),
+             get_tcp_listener()];
         {true,  true, true}  ->
             %% what is happening?
-            maybe_start_tcp_listener(),
-            maybe_start_legacy_listener(),
-            maybe_start_tls_listener()
+            rabbit_log:warning("Management plugin: TCP, SSL and legacy listeners configured. "
+                               "Only two configurations are supported at the same time. "
+                               "Ignoring the legacy configuration "),
+            [get_tcp_listener(),
+             get_tls_listener()]
     end,
-
-    rabbit_mgmt_sup_sup:start_link().
-
-stop(_State) ->
-    unregister_context(),
-    ok.
+    [ start_listener(Listener, IgnoreApps, NeedLogStartup)
+      || Listener <- Listeners ].
 
 has_configured_legacy_listener() ->
     has_configured_listener(listener).
@@ -75,71 +92,47 @@ has_configured_tls_listener() ->
     has_configured_listener(ssl_config).
 
 has_configured_listener(Key) ->
-    case rabbit_misc:get_env(rabbitmq_management, Key, undefined) of
+    case application:get_env(rabbitmq_management, Key, undefined) of
         undefined -> false;
         _         -> true
     end.
 
-maybe_start_legacy_listener() ->
-    case rabbit_misc:get_env(rabbitmq_management, listener, undefined) of
-        undefined -> ok;
-        Listener  ->
-            {ok, _} = register_context(Listener, []),
-            Type = case is_tls(Listener) of
-                       true  -> tls;
-                       false -> tcp
-                   end,
-            log_startup(Type, Listener),
-            ok
-    end.
+get_legacy_listener() ->
+    {ok, Listener} = application:get_env(rabbitmq_management, listener),
+    Listener.
 
-maybe_start_tls_listener() ->
-    case rabbit_misc:get_env(rabbitmq_management, ssl_config, undefined) of
-        undefined  -> ok;
-        Listener0  ->
-            Listener = [{ssl, true} | Listener0],
-            {ok, _}  = register_context(Listener, []),
-            log_startup(tls, Listener),
-            ok
-    end.
+get_tls_listener() ->
+    {ok, Listener0} = application:get_env(rabbitmq_management, ssl_config),
+    [{ssl, true} | Listener0].
 
-maybe_start_tcp_listener() ->
-    case rabbit_misc:get_env(rabbitmq_management, tcp_config, undefined) of
-        undefined -> ok;
-        Listener  ->
-            {ok, _} = register_context(Listener, []),
-            log_startup(tcp, Listener),
-            ok
-    end.
+get_tcp_listener() ->
+    application:get_env(rabbitmq_management, tcp_config, []).
 
-start_tcp_listener() ->
-    Listener = rabbit_misc:get_env(rabbitmq_management, tcp_config, []),
-    {ok, _} = register_context(Listener, []),
-    log_startup(tcp, Listener),
+start_listener(Listener, IgnoreApps, NeedLogStartup) ->
+    {Type, ContextName} = case is_tls(Listener) of
+        true  -> {tls, ?TLS_CONTEXT};
+        false -> {tcp, ?TCP_CONTEXT}
+    end,
+    {ok, _} = register_context(ContextName, Listener, IgnoreApps),
+    case NeedLogStartup of
+        true  -> log_startup(Type, Listener);
+        false -> ok
+    end,
     ok.
 
-%% At the point at which this is invoked we have both newly enabled
-%% apps and about-to-disable apps running (so that
-%% rabbit_mgmt_reset_handler can look at all of them to find
-%% extensions). Therefore we have to explicitly exclude
-%% about-to-disable apps from our new dispatcher.
-reset_dispatcher(IgnoreApps) ->
-    unregister_context(),
-    {ok, Listener} = application:get_env(rabbitmq_management, listener),
-    register_context(Listener, IgnoreApps).
-
-register_context(Listener0, IgnoreApps) ->
+register_context(ContextName, Listener0, IgnoreApps) ->
     M0 = maps:from_list(Listener0),
     %% include default port if it's not provided in the config
     %% as Cowboy won't start if the port is missing
     M1 = maps:merge(#{port => ?DEFAULT_PORT}, M0),
     rabbit_web_dispatch:register_context_handler(
-      ?CONTEXT, maps:to_list(M1), "",
+      ContextName, maps:to_list(M1), "",
       rabbit_mgmt_dispatcher:build_dispatcher(IgnoreApps),
       "RabbitMQ Management").
 
-unregister_context() ->
-    rabbit_web_dispatch:unregister_context(?CONTEXT).
+unregister_all_contexts() ->
+    rabbit_web_dispatch:unregister_context(?TCP_CONTEXT),
+    rabbit_web_dispatch:unregister_context(?TLS_CONTEXT).
 
 log_startup(tcp, Listener) ->
     rabbit_log:info("Management plugin: HTTP (non-TLS) listener started on port ~w", [port(Listener)]);

--- a/src/rabbit_mgmt_app.erl
+++ b/src/rabbit_mgmt_app.erl
@@ -73,9 +73,9 @@ start_configured_listener(IgnoreApps, NeedLogStartup) ->
              get_tcp_listener()];
         {true,  true, true}  ->
             %% what is happening?
-            rabbit_log:warning("Management plugin: TCP, SSL and legacy listeners configured. "
-                               "Only two configurations are supported at the same time. "
-                               "Ignoring the legacy configuration "),
+            rabbit_log:warning("Management plugin: TCP, TLS and a legacy (management.listener.*) listener are all configured. "
+                               "Only two listeners at a time are supported. "
+                               "Ignoring the legacy listener"),
             [get_tcp_listener(),
              get_tls_listener()]
     end,


### PR DESCRIPTION
When additional management-related plugin is started it restarts
a web dispatch context for rabbitmq management.
This restart should also use config changes from 50957aaf840d34ae9c396f83c9e1e71be8e5aa72
Because there can be two listeners now, there should be two
contexts registered in web dispatch.

This change also shows a warning if there are all three listeners configurations provided (`tcp_config`, `ssl_config` and `listener`). And will use `tcp_config` and `ssl_config`.

How to reproduce:
- Start a node with the management plugin
- Enable the shovel management plugin
- List the listeners with `rabbitmqctl status`

Try the same thing with tls and tcp listeners.

Follow-up to #618
[#161546916]