### PR TITLE
Make it possible to configure CSP and HSTS policy headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,11 @@ define PROJECT_ENV
 	    {management_db_cache_multiplier, 5},
 	    {process_stats_gc_timeout, 300000},
 	    {stats_event_max_backlog, 250},
+
 	    {cors_allow_origins, []},
-	    {cors_max_age, 1800}
+	    {cors_max_age, 1800},
+
+	    {content_security_policy, "default-src 'self'"}
 	  ]
 endef
 

--- a/priv/schema/rabbitmq_management.schema
+++ b/priv/schema/rabbitmq_management.schema
@@ -284,6 +284,34 @@ fun(Conf) ->
 end}.
 
 
+%% CSP (https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+
+{mapping, "management.csp.policy", "rabbitmq_management.content_security_policy", [
+    {datatype, string}
+]}.
+
+{translation, "rabbitmq_management.content_security_policy",
+fun(Conf) ->
+    case cuttlefish:conf_get("management.csp.policy", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        Value     -> Value
+    end
+end}.
+
+
+%% HSTS (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
+
+{mapping, "management.hsts.policy", "rabbitmq_management.strict_transport_security", [
+    {datatype, string}
+]}.
+
+{translation, "rabbitmq_management.strict_transport_security",
+fun(Conf) ->
+    case cuttlefish:conf_get("management.hsts.policy", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        Value     -> Value
+    end
+end}.
 
 %% ===========================================================================
 

--- a/src/rabbit_mgmt_csp.erl
+++ b/src/rabbit_mgmt_csp.erl
@@ -1,0 +1,37 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License at
+%% http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%% License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% The Original Code is RabbitMQ Management Plugin.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2018 Pivotal Software, Inc.  All rights reserved.
+%%
+
+%% Sets CSP header(s) on the response if configured,
+%% see https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP.
+
+-module(rabbit_mgmt_csp).
+
+-export([set_headers/1]).
+
+-define(CSP_HEADER, <<"content-security-policy">>).
+
+%%
+%% API
+%%
+
+set_headers(ReqData) ->
+    case application:get_env(rabbitmq_management, content_security_policy) of
+        undefined   -> ReqData;
+        {ok, Value} ->
+            cowboy_req:set_resp_header(?CSP_HEADER,
+                                       rabbit_data_coercion:to_binary(Value),
+                                       ReqData)
+    end.

--- a/src/rabbit_mgmt_headers.erl
+++ b/src/rabbit_mgmt_headers.erl
@@ -1,0 +1,43 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License at
+%% http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%% License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% The Original Code is RabbitMQ Management Plugin.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2018 Pivotal Software, Inc.  All rights reserved.
+%%
+
+%% This module contains helper functions that control
+%% response headers related to CORS, CSP, HSTS and so on.
+-module(rabbit_mgmt_headers).
+
+-export([set_common_permission_headers/2]).
+-export([set_cors_headers/2, set_hsts_headers/2, set_csp_headers/2]).
+
+%%
+%% API
+%%
+
+set_cors_headers(ReqData, Module) ->
+    rabbit_mgmt_cors:set_headers(ReqData, Module).
+
+set_hsts_headers(ReqData, _Module) ->
+    rabbit_mgmt_hsts:set_headers(ReqData).
+
+set_csp_headers(ReqData, _Module) ->
+    rabbit_mgmt_csp:set_headers(ReqData).
+
+set_common_permission_headers(ReqData0, EndpointModule) ->
+    lists:foldl(fun(Fun, ReqData) ->
+                        Fun(ReqData, EndpointModule)
+                end, ReqData0,
+               [fun set_csp_headers/2,
+                fun set_hsts_headers/2,
+                fun set_cors_headers/2]).

--- a/src/rabbit_mgmt_hsts.erl
+++ b/src/rabbit_mgmt_hsts.erl
@@ -1,0 +1,37 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License at
+%% http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%% License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% The Original Code is RabbitMQ Management Plugin.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2018 Pivotal Software, Inc.  All rights reserved.
+%%
+
+%% Sets HSTS header(s) on the response if configured,
+%% see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security.
+
+-module(rabbit_mgmt_hsts).
+
+-export([set_headers/1]).
+
+-define(HSTS_HEADER, <<"strict-transport-security">>).
+
+%%
+%% API
+%%
+
+set_headers(ReqData) ->
+    case application:get_env(rabbitmq_management, strict_transport_security) of
+        undefined   -> ReqData;
+        {ok, Value} ->
+            cowboy_req:set_resp_header(?HSTS_HEADER,
+                                       rabbit_data_coercion:to_binary(Value),
+                                       ReqData)
+    end.

--- a/src/rabbit_mgmt_wm_aliveness_test.erl
+++ b/src/rabbit_mgmt_wm_aliveness_test.erl
@@ -28,7 +28,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_binding.erl
+++ b/src/rabbit_mgmt_wm_binding.erl
@@ -26,7 +26,7 @@
 
 %%--------------------------------------------------------------------
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_bindings.erl
+++ b/src/rabbit_mgmt_wm_bindings.erl
@@ -28,7 +28,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, [Mode]) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), {Mode, #context{}}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), {Mode, #context{}}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_channel.erl
+++ b/src/rabbit_mgmt_wm_channel.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_channels.erl
+++ b/src/rabbit_mgmt_wm_channels.erl
@@ -28,7 +28,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_channels_vhost.erl
+++ b/src/rabbit_mgmt_wm_channels_vhost.erl
@@ -30,7 +30,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_cluster_name.erl
+++ b/src/rabbit_mgmt_wm_cluster_name.erl
@@ -27,7 +27,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_connection.erl
+++ b/src/rabbit_mgmt_wm_connection.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_connection_channels.erl
+++ b/src/rabbit_mgmt_wm_connection_channels.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_connections.erl
+++ b/src/rabbit_mgmt_wm_connections.erl
@@ -28,7 +28,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_connections_vhost.erl
+++ b/src/rabbit_mgmt_wm_connections_vhost.erl
@@ -30,7 +30,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_consumers.erl
+++ b/src/rabbit_mgmt_wm_consumers.erl
@@ -27,7 +27,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_definitions.erl
+++ b/src/rabbit_mgmt_wm_definitions.erl
@@ -32,7 +32,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_exchange.erl
+++ b/src/rabbit_mgmt_wm_exchange.erl
@@ -28,7 +28,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_exchange_publish.erl
+++ b/src/rabbit_mgmt_wm_exchange_publish.erl
@@ -27,7 +27,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_exchanges.erl
+++ b/src/rabbit_mgmt_wm_exchanges.erl
@@ -31,7 +31,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_extensions.erl
+++ b/src/rabbit_mgmt_wm_extensions.erl
@@ -25,7 +25,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_global_parameter.erl
+++ b/src/rabbit_mgmt_wm_global_parameter.erl
@@ -30,7 +30,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_global_parameters.erl
+++ b/src/rabbit_mgmt_wm_global_parameters.erl
@@ -25,7 +25,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_healthchecks.erl
+++ b/src/rabbit_mgmt_wm_healthchecks.erl
@@ -24,7 +24,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_limit.erl
+++ b/src/rabbit_mgmt_wm_limit.erl
@@ -28,7 +28,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_limits.erl
+++ b/src/rabbit_mgmt_wm_limits.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_node.erl
+++ b/src/rabbit_mgmt_wm_node.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_node_memory.erl
+++ b/src/rabbit_mgmt_wm_node_memory.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, [Mode]) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), {Mode, #context{}}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), {Mode, #context{}}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_node_memory_ets.erl
+++ b/src/rabbit_mgmt_wm_node_memory_ets.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, [Mode]) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), {Mode, #context{}}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), {Mode, #context{}}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_nodes.erl
+++ b/src/rabbit_mgmt_wm_nodes.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_operator_policies.erl
+++ b/src/rabbit_mgmt_wm_operator_policies.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_operator_policy.erl
+++ b/src/rabbit_mgmt_wm_operator_policy.erl
@@ -29,7 +29,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_overview.erl
+++ b/src/rabbit_mgmt_wm_overview.erl
@@ -28,7 +28,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_parameter.erl
+++ b/src/rabbit_mgmt_wm_parameter.erl
@@ -28,7 +28,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_parameters.erl
+++ b/src/rabbit_mgmt_wm_parameters.erl
@@ -27,7 +27,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_permission.erl
+++ b/src/rabbit_mgmt_wm_permission.erl
@@ -28,7 +28,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_permissions.erl
+++ b/src/rabbit_mgmt_wm_permissions.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_permissions_user.erl
+++ b/src/rabbit_mgmt_wm_permissions_user.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_permissions_vhost.erl
+++ b/src/rabbit_mgmt_wm_permissions_vhost.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_policies.erl
+++ b/src/rabbit_mgmt_wm_policies.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_policy.erl
+++ b/src/rabbit_mgmt_wm_policy.erl
@@ -28,7 +28,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_queue.erl
+++ b/src/rabbit_mgmt_wm_queue.erl
@@ -28,7 +28,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_queue_actions.erl
+++ b/src/rabbit_mgmt_wm_queue_actions.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_queue_get.erl
+++ b/src/rabbit_mgmt_wm_queue_get.erl
@@ -27,7 +27,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_queue_purge.erl
+++ b/src/rabbit_mgmt_wm_queue_purge.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_queues.erl
+++ b/src/rabbit_mgmt_wm_queues.erl
@@ -32,7 +32,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_reset.erl
+++ b/src/rabbit_mgmt_wm_reset.erl
@@ -25,7 +25,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_topic_permission.erl
+++ b/src/rabbit_mgmt_wm_topic_permission.erl
@@ -28,7 +28,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_topic_permissions.erl
+++ b/src/rabbit_mgmt_wm_topic_permissions.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_topic_permissions_user.erl
+++ b/src/rabbit_mgmt_wm_topic_permissions_user.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_topic_permissions_vhost.erl
+++ b/src/rabbit_mgmt_wm_topic_permissions_vhost.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_user.erl
+++ b/src/rabbit_mgmt_wm_user.erl
@@ -28,7 +28,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_users.erl
+++ b/src/rabbit_mgmt_wm_users.erl
@@ -30,7 +30,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, [Mode]) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), {Mode, #context{}}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), {Mode, #context{}}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_users_bulk_delete.erl
+++ b/src/rabbit_mgmt_wm_users_bulk_delete.erl
@@ -29,7 +29,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_vhost.erl
+++ b/src/rabbit_mgmt_wm_vhost.erl
@@ -30,7 +30,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_vhost_restart.erl
+++ b/src/rabbit_mgmt_wm_vhost_restart.erl
@@ -26,7 +26,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_vhosts.erl
+++ b/src/rabbit_mgmt_wm_vhosts.erl
@@ -30,7 +30,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/src/rabbit_mgmt_wm_whoami.erl
+++ b/src/rabbit_mgmt_wm_whoami.erl
@@ -25,7 +25,7 @@
 %%--------------------------------------------------------------------
 
 init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
 
 variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.

--- a/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -274,6 +274,62 @@
 
 
  %%
+ %% CSP
+ %%
+
+ {csp_policy_case1,
+  "management.csp.policy = default-src 'self'",
+  [
+   {rabbitmq_management, [
+                          {content_security_policy, "default-src 'self'"}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {csp_policy_case2,
+  "management.csp.policy = default-src https://onlinebanking.examplebank.com",
+  [
+   {rabbitmq_management, [
+                          {content_security_policy, "default-src https://onlinebanking.examplebank.com"}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {csp_policy_case3,
+  "management.csp.policy = default-src 'self' *.mailsite.com; img-src *",
+  [
+   {rabbitmq_management, [
+                          {content_security_policy, "default-src 'self' *.mailsite.com; img-src *"}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ %%
+ %% HSTS
+ %%
+
+ {hsts_policy_case1,
+  "management.hsts.policy = max-age=31536000; includeSubDomains",
+  [
+   {rabbitmq_management, [
+                          {strict_transport_security, "max-age=31536000; includeSubDomains"}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {csp_and_hsts_combined,
+  "management.csp.policy = default-src 'self' *.mailsite.com; img-src *
+   management.hsts.policy = max-age=31536000; includeSubDomains",
+  [
+   {rabbitmq_management, [
+                          {content_security_policy, "default-src 'self' *.mailsite.com; img-src *"},
+                          {strict_transport_security, "max-age=31536000; includeSubDomains"}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+
+ %%
  %% Legacy listener configuration
  %%
 


### PR DESCRIPTION
## Proposed Changes

This makes [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) and [HSTS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) policies configurable and sets their headers to every API endpoint, if present, much like we already do for CORS.

CSP has a reasonable default while HSTS must be configured by the user.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #623, #624)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #263.
Closes #264.

[#161584215]