### PR TITLE
Test that listeners are removed from mnesia when web dispatch is disabled

### DIFF
--- a/test/clustering_SUITE.erl
+++ b/test/clustering_SUITE.erl
@@ -60,7 +60,8 @@ groups() ->
                                exchange,
                                vhosts,
                                nodes,
-                               overview
+                               overview,
+                               disable_plugin
                               ]}
     ].
 
@@ -726,6 +727,17 @@ overview(Config) ->
     rabbit_ct_client_helpers:close_connection(Conn2),
 
     ok.
+
+disable_plugin(Config) ->
+    Node = get_node_config(Config, 0, nodename),
+    Status0 = rabbit_ct_broker_helpers:rpc(Config, Node, rabbit, status, []),
+    Listeners0 = proplists:get_value(listeners, Status0),
+    ?assert(lists:keymember(http, 1, Listeners0)),
+    rabbit_ct_broker_helpers:disable_plugin(Config, Node, 'rabbitmq_web_dispatch'),
+    Status = rabbit_ct_broker_helpers:rpc(Config, Node, rabbit, status, []),
+    Listeners = proplists:get_value(listeners, Status),
+    ?assert(not lists:keymember(http, 1, Listeners)),
+    rabbit_ct_broker_helpers:enable_plugin(Config, Node, 'rabbitmq_management').
 
 %%----------------------------------------------------------------------------
 %%


### PR DESCRIPTION
Web dispatch and management have to be disabled in the right order for the listeners to be removed.

Tests https://github.com/rabbitmq/rabbitmq-server/pull/1758

## Types of Changes
- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
