### PR TITLE
Take mode into account before accessing queue variable

### DIFF
--- a/priv/www/js/tmpl/publish.ejs
+++ b/priv/www/js/tmpl/publish.ejs
@@ -21,7 +21,7 @@
           <td><input type="text" name="routing_key" value=""/></td>
         </tr>
 <% } %>
-        <% if (is_classic(queue)) { %>
+        <% if (mode == 'queue' && is_classic(queue)) { %>
         <tr>
           <th><label>Delivery mode:</label></th>
           <td>


### PR DESCRIPTION
To reproduce issue:

* Start RabbitMQ with this plugin
* Navigate to exchanges page
* JS error popup will be seen, also in console