### PR TITLE
Limit chart ranges to those available via retention policies

### DIFF
--- a/priv/www/js/charts.js
+++ b/priv/www/js/charts.js
@@ -78,7 +78,7 @@ function chart_h3(id, heading, heading_help) {
 }
 
 function prefix_title(mode, range) {
-    var desc = CHART_PERIODS[range];
+    var desc = ALL_CHART_RANGES[range];
     if (mode == 'chart') {
         return desc.toLowerCase();
     }

--- a/priv/www/js/dispatcher.js
+++ b/priv/www/js/dispatcher.js
@@ -95,9 +95,8 @@ dispatcher_add(function(sammy) {
         });
 
     sammy.get('#/queues', function() {
-                          renderQueues();
-            });
-
+            renderQueues();
+        });
 
     sammy.get('#/queues/:vhost/:name', function() {
             var path = '/queues/' + esc(this.params['vhost']) + '/' + esc(this.params['name']);

--- a/priv/www/js/global.js
+++ b/priv/www/js/global.js
@@ -610,11 +610,11 @@ function setup_global_vars() {
 function setup_chart_ranges(srp) {
     var range_types = ['global', 'basic'];
     var default_ranges = {
-        '60':    ['60|5', 'Last minute'],
-        '600':   ['600|5', 'Last ten minutes'],
-        '3600':  ['3600|60', 'Last hour'],
-        '28800': ['28800|600', 'Last eight hours'],
-        '86400': ['86400|1800', 'Last day']
+        60:    ['60|5', 'Last minute'],
+        600:   ['600|5', 'Last ten minutes'],
+        3600:  ['3600|60', 'Last hour'],
+        28800: ['28800|600', 'Last eight hours'],
+        86400: ['86400|1800', 'Last day']
     };
 
     for (var range in default_ranges) {
@@ -627,19 +627,21 @@ function setup_chart_ranges(srp) {
     for (var i = 0; i < range_types.length; ++i) {
         var range_type = range_types[i];
         if (srp.hasOwnProperty(range_type)) {
-
-            // The last minute range is always valid but not
-            // returned by RabbitMQ
-            var last_minute = default_ranges['60'];
-            CHART_RANGES[range_type].push(last_minute);
-
             var srp_range_types = srp[range_type];
+            var last_minute_added = false;
             for (var j = 0; j < srp_range_types.length; ++j) {
                 var srp_range = srp_range_types[j];
                 if (default_ranges.hasOwnProperty(srp_range)) {
+                    if (srp_range === 60) {
+                        last_minute_added = true;
+                    }
                     var v = default_ranges[srp_range];
                     CHART_RANGES[range_type].push(v);
                 }
+            }
+            if (!last_minute_added) {
+                var last_minute = default_ranges[60];
+                CHART_RANGES[range_type].unshift(last_minute);
             }
         }
     }

--- a/priv/www/js/global.js
+++ b/priv/www/js/global.js
@@ -51,11 +51,8 @@ var NAVIGATION = {'Overview':    ['#/',            "management"],
                      "management"]
                  };
 
-var CHART_PERIODS = {'60|5':       'Last minute',
-                     '600|5':      'Last ten minutes',
-                     '3600|60':    'Last hour',
-                     '28800|600':  'Last eight hours',
-                     '86400|1800': 'Last day'};
+var CHART_RANGES = {'global': [], 'basic': []};
+var ALL_CHART_RANGES = {};
 
 var COLUMNS =
     {'exchanges' :
@@ -606,6 +603,46 @@ function setup_global_vars() {
     queue_type = "classic";
     current_vhost = get_pref('vhost');
     exchange_types = overview.exchange_types;
+
+    setup_chart_ranges(overview.sample_retention_policies);
+}
+
+function setup_chart_ranges(srp) {
+    var range_types = ['global', 'basic'];
+    var default_ranges = {
+        '60':    ['60|5', 'Last minute'],
+        '600':   ['600|5', 'Last ten minutes'],
+        '3600':  ['3600|60', 'Last hour'],
+        '28800': ['28800|600', 'Last eight hours'],
+        '86400': ['86400|1800', 'Last day']
+    };
+
+    for (var range in default_ranges) {
+        var data = default_ranges[range];
+        var range = data[0];
+        var desc = data[1];
+        ALL_CHART_RANGES[range] = desc;
+    }
+
+    for (var i = 0; i < range_types.length; ++i) {
+        var range_type = range_types[i];
+        if (srp.hasOwnProperty(range_type)) {
+
+            // The last minute range is always valid but not
+            // returned by RabbitMQ
+            var last_minute = default_ranges['60'];
+            CHART_RANGES[range_type].push(last_minute);
+
+            var srp_range_types = srp[range_type];
+            for (var j = 0; j < srp_range_types.length; ++j) {
+                var srp_range = srp_range_types[j];
+                if (default_ranges.hasOwnProperty(srp_range)) {
+                    var v = default_ranges[srp_range];
+                    CHART_RANGES[range_type].push(v);
+                }
+            }
+        }
+    }
 }
 
 function expand_user_tags(tags) {

--- a/priv/www/js/tmpl/rate-options.ejs
+++ b/priv/www/js/tmpl/rate-options.ejs
@@ -2,7 +2,7 @@
    var id = span.attr('for');
    var mode = get_pref('rate-mode-' + id);
    var size = get_pref('chart-size-' + id);
-   var range = get_pref('chart-range');
+   var range_pref = get_pref('chart-range');
 %>
 
 <form action="#/rate-options" method="put" class="auto-submit">
@@ -40,9 +40,13 @@
       <th><label>Chart range:</label></th>
       <td>
 <%
-   for (p in CHART_PERIODS) {
+   var range_type = get_chart_range_type(id);
+   for (var i = 0; i < CHART_RANGES[range_type].length; ++i) {
+      var data = CHART_RANGES[range_type][i];
+      var range = data[0];
+      var desc = data[1];
 %>
-    <%= fmt_radio('range', CHART_PERIODS[p], p, range) %>
+    <%= fmt_radio('range', desc, range, range_pref) %>
 <%
    }
 %>

--- a/src/rabbit_mgmt_wm_overview.erl
+++ b/src/rabbit_mgmt_wm_overview.erl
@@ -127,7 +127,7 @@ transform_retention_policy(Pol, Policies) ->
     end.
 
 transform_retention_intervals([], Acc) ->
-    lists:reverse(Acc);
+    lists:sort(Acc);
 transform_retention_intervals([{MaxAgeInSeconds, _}|Rest], Acc) ->
     %
     % Seconds | Interval


### PR DESCRIPTION
Fixes #635 

### Current behavior

Run broker and PerfTest for at least 8 hours. Then, open the management UI, choose a queue, and choose a chart interval of "Last 8 hours" or "Last day". The chart will be incorrect as described in #475.

### Testing with this PR applied

When you bring up the management UI and navigate to a queue, then its chart range popup (by clicking on the range selector text "Last ... "), you will only see options for last minute, last 10 minutes and last hour as dictated by the default `sample_retention_policies` setting which only stores one hour of `basic` data (used by queues).

If you select "Last 8 hours" in the Overview page, then go to a queue, you will notice the range change to "Last hour" since "Last 8 hours" is not valid for the chart.

If you modify the retention policy as in #475 to store more data and restart the broker, you should see the other time ranges available for the queues chart.