### PR TITLE
Restore link to exclusive queue owner connection

### DIFF
--- a/priv/www/js/formatters.js
+++ b/priv/www/js/formatters.js
@@ -105,6 +105,11 @@ function fmt_features_short(obj) {
     var res = '';
     var features = args_to_features(obj);
 
+    if (obj.owner_pid_details != undefined) {
+        res += '<acronym title="Exclusive queue: click for owning connection">'
+            + link_conn(obj.owner_pid_details.name, "Excl") + '</acronym> ';
+    }
+
     for (var k in ALL_ARGS) {
         if (features[k] != undefined) {
             res += '<abbr title="' + k + ': ' + fmt_string(features[k]) +

--- a/priv/www/js/tmpl/queue.ejs
+++ b/priv/www/js/tmpl/queue.ejs
@@ -22,6 +22,12 @@
         <th>Operator policy</th>
         <td><%= fmt_string(queue.operator_policy, '') %></td>
       </tr>
+      <% if (queue.owner_pid_details != undefined) { %>
+        <tr>
+          <th>Exclusive owner</th>
+          <td><%= link_conn(queue.owner_pid_details.name) %></td>
+        </tr>
+      <% } %>
       <tr>
         <th>Effective policy definition</th>
         <td><%= fmt_table_short(queue.effective_policy_definition) %></td>

--- a/src/rabbit_mgmt_db.erl
+++ b/src/rabbit_mgmt_db.erl
@@ -386,7 +386,8 @@ detail_queue_stats(Ranges, Objs, Interval) ->
                  {incoming,
                   detail_stats(QueueData, queue_exchange_stats_publish,
                                fine_stats, first(Id), Ranges, Interval)}],
-       {Pid, combine(Props, Obj) ++ Stats ++ StatsD ++ Consumers}
+       Details = augment_details(Obj, []),
+       {Pid, combine(Props, Obj) ++ Stats ++ StatsD ++ Consumers ++ Details}
        end || Obj <- Objs]),
 
    % patch up missing channel details


### PR DESCRIPTION
Fixes #467 

Note that the name `owner_pid_details` remains the same as the augment function is used elsewhere.