### PR TITLE
Allow for password_hash instead of password when declaring users

### DIFF
--- a/bin/rabbitmqadmin
+++ b/bin/rabbitmqadmin
@@ -108,7 +108,7 @@ DECLARABLE = {
                                  'routing_key': '', 'arguments': {}}},
     'vhost':      {'mandatory': ['name'],
                    'optional':  {'tracing': None}},
-    'user':       {'mandatory': ['name', 'password', 'tags'],
+    'user':       {'mandatory': ['name', ['password', 'password_hash'], 'tags'],
                    'optional':  {}},
     'permission': {'mandatory': ['vhost', 'user', 'configure', 'write', 'read'],
                    'optional':  {}},
@@ -730,15 +730,28 @@ class Management:
             assert_usage("=" in arg,
                          'Argument "{0}" not in format name=value'.format(arg))
             (name, value) = arg.split("=", 1)
-            assert_usage(name in mandatory or name in optional.keys(),
+            mandatory_keys = []
+            for key in mandatory:
+                if type(key) is list:
+                    for subkey in key:
+                        mandatory_keys.append(subkey)
+                else:
+                    mandatory_keys.append(key)
+            assert_usage(name in mandatory_keys or name in optional.keys(),
                          'Argument "{0}" not recognised'.format(name))
             if 'json' in obj and name in obj['json']:
                 upload[name] = self.parse_json(value)
             else:
                 upload[name] = value
         for m in mandatory:
-            assert_usage(m in upload.keys(),
-                         'mandatory argument "{0}" required'.format(m))
+            if type(m) is list:
+                a_set = set(m)
+                b_set = set(upload.keys())
+                assert_usage((a_set & b_set),
+                             'mandatory one-of arguments "{0}" required'.format(m))
+            else:
+                assert_usage(m in upload.keys(),
+                             'mandatory argument "{0}" required'.format(m))
         if 'vhost' not in mandatory:
             upload['vhost'] = self.options.vhost or self.options.declare_vhost
         uri_args = {}

--- a/test/rabbit_mgmt_rabbitmqadmin_SUITE.erl
+++ b/test/rabbit_mgmt_rabbitmqadmin_SUITE.erl
@@ -196,6 +196,7 @@ users(Config) ->
     {ok, ["guest"]} = run_list(Config, l("users")),
     {error, _, _} = run(Config, ["declare", "user", "name=foo"]),
     {ok, _} = run(Config, ["declare", "user", "name=foo", "password=pass", "tags="]),
+    {ok, _} = run(Config, ["declare", "user", "name=foo", "password_hash=0qUsZVcRBQ1aU+sln631sKiEMSP9AOGHxuz4Rk01Jx4hwr2b", "tags="]),
     {ok, ["foo", "guest"]} = run_list(Config, l("users")),
     {ok, _} = run(Config, ["delete", "user", "name=foo"]),
     {ok, ["guest"]} = run_list(Config, l("users")).


### PR DESCRIPTION
## Proposed Changes

This allows for the use of password_hash instead of password when declaring a user. Avoids having an actual password where not required.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the mailing list. We're here to help! This is simply a reminder
of what we are going to look for before merging your code._

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
