### PR TITLE
Add docs for password_hash_algorithm to HTTP api

### DIFF
--- a/priv/www/api/index.html
+++ b/priv/www/api/index.html
@@ -725,6 +725,9 @@ or:
         are <code>administrator</code>, <code>monitoring</code> and <code>management</code>.
         <code>password_hash</code> must be generated using the algorithm described
         <a href="http://rabbitmq.com/passwords.html#computing-password-hash">here</a>.
+        You may also specify the hash being used by adding the <code>hashing_algorithm</code>
+        key to the body. Currently recognised algorithms are <code>rabbit_password_hashing_sha256</code>, 
+        <code>rabbit_password_hashing_sha512</code>, and <code>rabbit_password_hashing_md5</code>.
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
## Proposed Changes

To wrap up #641 - here is a small addition to the HTTP api docs to point out the password_hash_algorithm key.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

