### PR TITLE
Support cipher suites and more TLS listener options

### DIFF
--- a/priv/schema/rabbitmq_management.schema
+++ b/priv/schema/rabbitmq_management.schema
@@ -72,6 +72,42 @@
 {mapping, "management.ssl.password", "rabbitmq_management.ssl_config.password",
     [{datatype, string}]}.
 
+{mapping, "management.ssl.honor_cipher_order", "rabbitmq_management.ssl_config.honor_cipher_order",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "management.ssl.honor_ecc_order", "rabbitmq_management.ssl_config.honor_ecc_order",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "management.ssl.reuse_sessions", "rabbitmq_management.ssl_config.reuse_sessions",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "management.ssl.secure_renegotiate", "rabbitmq_management.ssl_config.secure_renegotiate",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "management.ssl.client_renegotiation", "rabbitmq_management.ssl_config.client_renegotiation",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "management.ssl.depth", "rabbitmq_management.ssl_config.depth",
+    [{datatype, integer}, {validators, ["byte"]}]}.
+
+{mapping, "management.ssl.versions.$version", "rabbitmq_management.ssl_config.versions",
+    [{datatype, atom}]}.
+
+{translation, "rabbitmq_management.ssl_config.versions",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("management.ssl.versions", Conf),
+    [V || {_, V} <- Settings]
+end}.
+
+{mapping, "management.ssl.ciphers.$cipher", "rabbitmq_management.ssl_config.ciphers",
+    [{datatype, string}]}.
+
+{translation, "rabbitmq_management.ssl_config.ciphers",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("management.ssl.ciphers", Conf),
+    [V || {_, V} <- Settings]
+end}.
+
 {mapping, "management.ssl.compress", "rabbitmq_management.ssl_config.cowboy_opts.compress",
     [{datatype, {enum, [true, false]}}]}.
 {mapping, "management.ssl.idle_timeout", "rabbitmq_management.ssl_config.cowboy_opts.idle_timeout",
@@ -161,6 +197,32 @@ fun(Conf) ->
     [ list_to_binary(V) || {_, V} <- Settings ]
 end}.
 
+{mapping, "management.listener.ssl_opts.honor_cipher_order", "rabbitmq_management.listener.ssl_opts.honor_cipher_order",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "management.listener.ssl_opts.honor_ecc_order", "rabbitmq_management.listener.ssl_opts.honor_ecc_order",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "management.listener.ssl_opts.reuse_sessions", "rabbitmq_management.listener.ssl_opts.reuse_sessions",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "management.listener.ssl_opts.secure_renegotiate", "rabbitmq_management.listener.ssl_opts.secure_renegotiate",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "management.listener.ssl_opts.client_renegotiation", "rabbitmq_management.listener.ssl_opts.client_renegotiation",
+    [{datatype, {enum, [true, false]}}]}.
+
+
+{mapping, "management.listener.ssl_opts.versions.$version", "rabbitmq_management.listener.ssl_opts.versions",
+    [{datatype, atom}]}.
+
+{translation, "rabbitmq_management.listener.ssl_opts.versions",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("management.listener.ssl_opts.versions", Conf),
+    [ V || {_, V} <- Settings ]
+end}.
+
+
 {mapping, "management.listener.ssl_opts.cert", "rabbitmq_management.listener.ssl_opts.cert",
     [{datatype, string}]}.
 
@@ -168,9 +230,6 @@ end}.
 fun(Conf) ->
     list_to_binary(cuttlefish:conf_get("management.listener.ssl_opts.cert", Conf))
 end}.
-
-{mapping, "management.listener.ssl_opts.client_renegotiation", "rabbitmq_management.listener.ssl_opts.client_renegotiation",
-    [{datatype, {enum, [true, false]}}]}.
 
 {mapping, "management.listener.ssl_opts.crl_check", "rabbitmq_management.listener.ssl_opts.crl_check",
     [{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
@@ -188,9 +247,6 @@ end}.
 
 {mapping, "management.listener.ssl_opts.dhfile", "rabbitmq_management.listener.ssl_opts.dhfile",
     [{datatype, string}, {validators, ["file_accessible"]}]}.
-
-{mapping, "management.listener.ssl_opts.honor_cipher_order", "rabbitmq_management.listener.ssl_opts.honor_cipher_order",
-    [{datatype, {enum, [true, false]}}]}.
 
 {mapping, "management.listener.ssl_opts.key.RSAPrivateKey", "rabbitmq_management.listener.ssl_opts.key",
     [{datatype, string}]}.
@@ -220,21 +276,6 @@ end}.
 
 {mapping, "management.listener.ssl_opts.psk_identity", "rabbitmq_management.listener.ssl_opts.psk_identity",
     [{datatype, string}]}.
-
-{mapping, "management.listener.ssl_opts.reuse_sessions", "rabbitmq_management.listener.ssl_opts.reuse_sessions",
-    [{datatype, {enum, [true, false]}}]}.
-
-{mapping, "management.listener.ssl_opts.secure_renegotiate", "rabbitmq_management.listener.ssl_opts.secure_renegotiate",
-    [{datatype, {enum, [true, false]}}]}.
-
-{mapping, "management.listener.ssl_opts.versions.$version", "rabbitmq_management.listener.ssl_opts.versions",
-    [{datatype, atom}]}.
-
-{translation, "rabbitmq_management.listener.ssl_opts.versions",
-fun(Conf) ->
-    Settings = cuttlefish_variable:filter_by_prefix("management.listener.ssl_opts.versions", Conf),
-    [ V || {_, V} <- Settings ]
-end}.
 
 
 %% A custom path prefix for all HTTP request handlers.

--- a/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -141,6 +141,59 @@
                         ]}],
   [rabbitmq_management]},
 
+ {tls_listener_cipher_suites,
+  "management.ssl.ip   = 192.168.1.2
+   management.ssl.port = 15671
+   management.ssl.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+   management.ssl.certfile = test/config_schema_SUITE_data/certs/cert.pem
+   management.ssl.keyfile = test/config_schema_SUITE_data/certs/key.pem
+
+   management.ssl.honor_cipher_order   = true
+   management.ssl.honor_ecc_order      = true
+   management.ssl.client_renegotiation = false
+   management.ssl.secure_renegotiate   = true
+
+   management.ssl.versions.1 = tlsv1.2
+   management.ssl.versions.2 = tlsv1.1
+
+   management.ssl.ciphers.1 = ECDHE-ECDSA-AES256-GCM-SHA384
+   management.ssl.ciphers.2 = ECDHE-RSA-AES256-GCM-SHA384
+   management.ssl.ciphers.3 = ECDHE-ECDSA-AES256-SHA384
+   management.ssl.ciphers.4 = ECDHE-RSA-AES256-SHA384
+   management.ssl.ciphers.5 = ECDH-ECDSA-AES256-GCM-SHA384
+   management.ssl.ciphers.6 = ECDH-RSA-AES256-GCM-SHA384
+   management.ssl.ciphers.7 = ECDH-ECDSA-AES256-SHA384
+   management.ssl.ciphers.8 = ECDH-RSA-AES256-SHA384
+   management.ssl.ciphers.9 = DHE-RSA-AES256-GCM-SHA384",
+  [{rabbitmq_management,[
+                         {ssl_config,[
+                                      {ip, "192.168.1.2"},
+                                      {port,15671},
+                                      {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
+                                      {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+                                      {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
+
+                                      {honor_cipher_order,   true},
+                                      {honor_ecc_order,      true},
+                                      {client_renegotiation, false},
+                                      {secure_renegotiate,   true},
+
+                                      {versions,['tlsv1.2','tlsv1.1']},
+                                      {ciphers, [
+                                                 "DHE-RSA-AES256-GCM-SHA384",
+                                                 "ECDH-ECDSA-AES256-GCM-SHA384",
+                                                 "ECDH-ECDSA-AES256-SHA384",
+                                                 "ECDH-RSA-AES256-GCM-SHA384",
+                                                 "ECDH-RSA-AES256-SHA384",
+                                                 "ECDHE-ECDSA-AES256-GCM-SHA384",
+                                                 "ECDHE-ECDSA-AES256-SHA384",
+                                                 "ECDHE-RSA-AES256-GCM-SHA384",
+                                                 "ECDHE-RSA-AES256-SHA384"
+                                                ]}
+                                     ]}
+                        ]}],
+  [rabbitmq_management]},
+
  {tls_listener_server_opts_compress,
   "management.ssl.compress = true",
   [


### PR DESCRIPTION
## Proposed Changes

This adds support for more TLS listener options in the new style config format, in particular, the cipher suites:

``` ini
management.ssl.honor_cipher_order  = true
management.ssl.honor_ecc_order      = true
management.ssl.client_renegotiation = false
management.ssl.secure_renegotiate   = true

management.ssl.versions.1 = tlsv1.2
management.ssl.versions.2 = tlsv1.1

management.ssl.ciphers.1 = ECDHE-ECDSA-AES256-GCM-SHA384
management.ssl.ciphers.2 = ECDHE-RSA-AES256-GCM-SHA384
management.ssl.ciphers.3 = ECDHE-ECDSA-AES256-SHA384
management.ssl.ciphers.4 = ECDHE-RSA-AES256-SHA384
management.ssl.ciphers.5 = ECDH-ECDSA-AES256-GCM-SHA384
management.ssl.ciphers.6 = ECDH-RSA-AES256-GCM-SHA384
management.ssl.ciphers.7 = ECDH-ECDSA-AES256-SHA384
management.ssl.ciphers.8 = ECDH-RSA-AES256-SHA384
management.ssl.ciphers.9 = DHE-RSA-AES256-GCM-SHA384
```

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue …)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #643.

References https://github.com/rabbitmq/rabbitmq-server/issues/1712, rabbitmq/rabbitmq-web-stomp#101, rabbitmq/rabbitmq-web-mqtt#45.

[#162844028]