### PR TITLE
Add queue: move type before name

### DIFF
--- a/priv/www/js/tmpl/queues.ejs
+++ b/priv/www/js/tmpl/queues.ejs
@@ -209,10 +209,6 @@
         <tr><td><input type="hidden" name="vhost" value="<%= fmt_string(vhosts[0].name) %>"/></td></tr>
 <% } %>
         <tr>
-          <th><label>Name:</label></th>
-          <td><input type="text" name="name"/><span class="mand">*</span></td>
-        </tr>
-        <tr>
           <th><label>Type:</label></th>
           <td>
             <select name="queuetype" onchange="select_queue_type(queuetype)">
@@ -225,7 +221,11 @@
             </select>
           </td>
         </tr>
-        <% if (queue_type == "classic") { %>
+        <tr>
+          <th><label>Name:</label></th>
+          <td><input type="text" name="name"/><span class="mand">*</span></td>
+        </tr>
+<% if (queue_type == "classic") { %>
         <tr>
           <th><label>Durability:</label></th>
           <td>
@@ -235,6 +235,7 @@
             </select>
           </td>
         </tr>
+<% } %>
 <%
   if (nodes_interesting) {
    var nodes = JSON.parse(sync_get('/nodes'));
@@ -250,6 +251,7 @@
           </td>
         </tr>
 <% } %>
+<% if (queue_type == "classic") { %>
         <tr>
           <th><label>Auto delete: <span class="help" id="queue-auto-delete"></span></label></th>
           <td>


### PR DESCRIPTION
As the rest of the form is refreshed upon change so it makes sense for
this to be the first item users should choose.

Also added the nodes options for quorum queues so that there is a good
change that the initial leader will be on the selected node.

[#163286660]
[#163651667]
