### PR TITLE
Consume request body in full

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -815,7 +815,7 @@ with_vhost_and_props(Fun, ReqData, Context) ->
             not_found(rabbit_data_coercion:to_binary("vhost_not_found"),
                       ReqData, Context);
         VHost ->
-            {ok, Body, ReqData1} = cowboy_req:read_body(ReqData),
+            {ok, Body, ReqData1} = read_complete_body(ReqData),
             case decode(Body) of
                 {ok, Props} ->
                     try

--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -34,7 +34,7 @@
          filter_vhost/3]).
 -export([filter_conn_ch_list/3, filter_user/2, list_login_vhosts/2]).
 -export([with_decode/5, decode/1, decode/2, set_resp_header/3,
-         args/1]).
+         args/1, read_complete_body/1]).
 -export([reply_list/3, reply_list/5, reply_list/4,
          sort_list/2, destination_type/1, reply_list_or_paginate/3
          ]).
@@ -710,8 +710,16 @@ id0(Key, ReqData) ->
         Id        -> Id
     end.
 
+read_complete_body(Req) ->
+    read_complete_body(Req, <<"">>).
+read_complete_body(Req0, Acc) ->
+    case cowboy_req:read_body(Req0) of
+        {ok, Data, Req}   -> {ok, <<Acc/binary, Data/binary>>, Req};
+        {more, Data, Req} -> read_complete_body(Req, <<Acc/binary, Data/binary>>)
+    end.
+
 with_decode(Keys, ReqData, Context, Fun) ->
-    {ok, Body, ReqData1} = cowboy_req:read_body(ReqData),
+    {ok, Body, ReqData1} = read_complete_body(ReqData),
     with_decode(Keys, Body, ReqData1, Context, Fun).
 
 with_decode(Keys, Body, ReqData, Context, Fun) ->

--- a/src/rabbit_mgmt_wm_bindings.erl
+++ b/src/rabbit_mgmt_wm_bindings.erl
@@ -69,7 +69,7 @@ to_json(ReqData, {Mode, Context}) ->
       ReqData, {Mode, Context}).
 
 accept_content(ReqData0, {_Mode, Context}) ->
-    {ok, Body, ReqData} = cowboy_req:read_body(ReqData0),
+    {ok, Body, ReqData} = rabbit_mgmt_util:read_complete_body(ReqData0),
     Source = rabbit_mgmt_util:id(source, ReqData),
     Dest = rabbit_mgmt_util:id(destination, ReqData),
     DestType = rabbit_mgmt_util:id(dtype, ReqData),

--- a/src/rabbit_mgmt_wm_definitions.erl
+++ b/src/rabbit_mgmt_wm_definitions.erl
@@ -90,7 +90,7 @@ all_definitions(ReqData, Context) ->
       Context).
 
 accept_json(ReqData0, Context) ->
-    {ok, Body, ReqData} = cowboy_req:read_body(ReqData0),
+    {ok, Body, ReqData} = rabbit_mgmt_util:read_complete_body(ReqData0),
     accept(Body, ReqData, Context).
 
 vhost_definitions(ReqData, VHost, Context) ->

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -124,6 +124,7 @@ all_tests() -> [
     get_encoding_test,
     get_fail_test,
     publish_test,
+    publish_large_message_test,
     publish_accept_json_test,
     publish_fail_test,
     publish_base64_test,
@@ -2441,23 +2442,49 @@ get_fail_test(Config) ->
     http_delete(Config, "/users/myuser", {group, '2xx'}),
     passed.
 
+
+-define(LARGE_BODY_BYTES, 25000000).
+
 publish_test(Config) ->
     Headers = #{'x-forwarding' => [#{uri => <<"amqp://localhost/%2F/upstream">>}]},
     Msg = msg(<<"publish_test">>, Headers, <<"Hello world">>),
     http_put(Config, "/queues/%2F/publish_test", #{}, {group, '2xx'}),
     ?assertEqual(#{routed => true},
-                 http_post(Config, "/exchanges/%2F/amq.default/publish", Msg, ?OK)),
+                  http_post(Config, "/exchanges/%2F/amq.default/publish", Msg, ?OK)),
     [Msg2] = http_post(Config, "/queues/%2F/publish_test/get", [{ackmode, ack_requeue_false},
-                                                           {count,    1},
-                                                           {encoding, auto}], ?OK),
+                                                                {count,    1},
+                                                                {encoding, auto}], ?OK),
     assert_item(Msg, Msg2),
     http_post(Config, "/exchanges/%2F/amq.default/publish", Msg2, ?OK),
     [Msg3] = http_post(Config, "/queues/%2F/publish_test/get", [{ackmode, ack_requeue_false},
-                                                           {count,    1},
-                                                           {encoding, auto}], ?OK),
+                                                               {count,    1},
+                                                               {encoding, auto}], ?OK),
     assert_item(Msg, Msg3),
     http_delete(Config, "/queues/%2F/publish_test", {group, '2xx'}),
     passed.
+
+publish_large_message_test(Config) ->
+  Headers = #{'x-forwarding' => [#{uri => <<"amqp://localhost/%2F/upstream">>}]},
+  Body = binary:copy(<<"a">>, ?LARGE_BODY_BYTES),
+  Msg = msg(<<"publish_accept_json_test">>, Headers, Body),
+  http_put(Config, "/queues/%2F/publish_accept_json_test", #{}, {group, '2xx'}),
+  ?assertEqual(#{routed => true},
+               http_post_accept_json(Config, "/exchanges/%2F/amq.default/publish",
+                                     Msg, ?OK)),
+
+  [Msg2] = http_post_accept_json(Config, "/queues/%2F/publish_accept_json_test/get",
+                                 [{ackmode, ack_requeue_false},
+                                  {count, 1},
+                                  {encoding, auto}], ?OK),
+  assert_item(Msg, Msg2),
+  http_post_accept_json(Config, "/exchanges/%2F/amq.default/publish", Msg2, ?OK),
+  [Msg3] = http_post_accept_json(Config, "/queues/%2F/publish_accept_json_test/get",
+                                 [{ackmode, ack_requeue_false},
+                                  {count, 1},
+                                  {encoding, auto}], ?OK),
+  assert_item(Msg, Msg3),
+  http_delete(Config, "/queues/%2F/publish_accept_json_test", {group, '2xx'}),
+  passed.
 
 publish_accept_json_test(Config) ->
     Headers = #{'x-forwarding' => [#{uri => <<"amqp://localhost/%2F/upstream">>}]},


### PR DESCRIPTION
## Proposed Changes

This makes use HTTP request body is consumed in full by handling both possible return values
of `cowboy_req:read_body/1`.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #657)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #657.