### PR TITLE
Format terminated status for queues as yellow.

### DIFF
--- a/priv/www/js/formatters.js
+++ b/priv/www/js/formatters.js
@@ -562,8 +562,8 @@ function fmt_object_state(obj) {
     else if (obj.state == 'terminated') {
         colour = 'yellow';
         var terminated_by = "";
-        if(typeof(obj.terminated_by) === "string"){
-            terminated_by = " by \"" + obj.terminated_by + "\""
+        if (obj.terminated_by) {
+            terminated_by = " by \"" + String(obj.terminated_by) + "\"";
         }
         explanation = 'The queue is being deleted' + terminated_by + ".";
     }

--- a/priv/www/js/formatters.js
+++ b/priv/www/js/formatters.js
@@ -559,6 +559,14 @@ function fmt_object_state(obj) {
         colour = 'yellow';
         explanation = 'Publishing rate recently throttled by server.';
     }
+    else if (obj.state == 'terminated') {
+        colour = 'yellow';
+        var terminated_by = "";
+        if(typeof(obj.terminated_by) === "string"){
+            terminated_by = " by \"" + obj.terminated_by + "\""
+        }
+        explanation = 'The queue is being deleted' + terminated_by + ".";
+    }
     else if (obj.state == 'down') {
         colour = 'red';
         explanation = 'The queue is located on a cluster node or nodes that ' +
@@ -948,7 +956,7 @@ function fmt_page_size_request(template, defaultPageSize){
     if  ((defaultPageSize == undefined) || (defaultPageSize < 0)) {
         defaultPageSize = 100;
     }
-        
+
     var result = stored_value_or_default(template + '_current_page_size', defaultPageSize);
     if (result > 500) {
         // hard limit


### PR DESCRIPTION
Addition to https://github.com/rabbitmq/rabbitmq-management-agent/pull/75

Show terminated status as yellow square with the clarification message that the queue is being deleted.

Should the status also say that it's being deleted?