### PR TITLE
rabbitmqadmin: add a missing mandatory parameter to {declare,delete} vhost_limit

### DIFF
--- a/bin/rabbitmqadmin
+++ b/bin/rabbitmqadmin
@@ -138,7 +138,7 @@ DECLARABLE = {
     'operator_policy': {'mandatory': ['name', 'pattern', 'definition'],
                         'json':      ['definition', 'priority'],
                         'optional':  {'priority': 0, 'apply-to': None}},
-    'vhost_limit': {'mandatory': ['name', 'value'],
+    'vhost_limit': {'mandatory': ['vhost', 'name', 'value'],
                     'json': ['value'],
                     'optional': {}},
     }
@@ -154,7 +154,7 @@ DELETABLE = {
     'parameter':  {'mandatory': ['component', 'name']},
     'policy':     {'mandatory': ['name']},
     'operator_policy': {'mandatory': ['name']},
-    'vhost_limit': {'mandatory': ['name']}
+    'vhost_limit': {'mandatory': ['vhost', 'name']}
     }
 
 CLOSABLE = {


### PR DESCRIPTION
## Proposed Changes

This adds a missing mandatory parameter to

```
rabbitmqadmin declare vhost_limit vhost=management-666 name="max-connections" value=123

rabbitmqadmin delete vhost_limit vhost=management-666 name="max-connections"
```

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #667)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

To test, create a virtual host named `management-666`, then:

``` shell
./bin/rabbitmqadmin declare vhost_limit vhost=management-666 name="max-connections" value=123
./bin/rabbitmqadmin list vhost_limits
./bin/rabbitmqadmin delete vhost_limit vhost=management-666 name="max-connections"
./bin/rabbitmqadmin list vhost_limits
```

References #666.