### PR TITLE
/api/vhost-limits/{vhost} does not support PUT

### DIFF
--- a/src/rabbit_mgmt_wm_limits.erl
+++ b/src/rabbit_mgmt_wm_limits.erl
@@ -32,7 +32,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 allowed_methods(ReqData, Context) ->
-    {[<<"GET">>, <<"PUT">>, <<"OPTIONS">>], ReqData, Context}.
+    {[<<"GET">>, <<"OPTIONS">>], ReqData, Context}.
 
 %% Admin user can see all vhosts
 
@@ -66,4 +66,3 @@ limits(ReqData, Context) ->
             end
     end.
 %%--------------------------------------------------------------------
-


### PR DESCRIPTION
## Proposed Changes

There is no UI that allows for N limits to be changed,
no docs for PUT support and no code to handle the updates.
Discovered as part of #666.

Originally added in f608459cb0c21b3c7c0af090303974a41b78b17a without
a detailed justification.

## Types of Changes

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

References #666.
