### PR TITLE
Corrrectly display multiple upstream URIs

### DIFF
--- a/priv/www/js/formatters.js
+++ b/priv/www/js/formatters.js
@@ -617,7 +617,14 @@ function fmt_shortened_uri(uri) {
 }
 
 function fmt_uri_with_credentials(uri) {
-    if (typeof uri == 'string') {
+    if (typeof uri == 'object') {
+        var res = [];
+        for (i in uri) {
+            res.push(fmt_uri_with_credentials(uri[i]));
+        }
+        return res;
+    }
+    else if (typeof uri == 'string') {
         // mask password
         var mask = /^([a-zA-Z0-9+-.]+):\/\/(.*):(.*)@/;
         return uri.replace(mask, "$1://$2:[redacted]@");


### PR DESCRIPTION
## Proposed Changes

This pull request makes federation page correctly display upstreams with multiple URIs configured:

Federations accepts multiplie URIs to configure upstreams:

### single upstream
```json
{
  "component": "federation-upstream",
  "vhost": "/",
  "name": "single-upstream",
  "value": {
    "uri": "amqp://guest:guest@rabbit2",
    "ack-mode": "on-confirm",
    "trust-user-id": false
  }
}
```

### multiple upstreams
```json
{
  "component": "federation-upstream",
  "vhost": "/",
  "name": "multi-upstreams",
  "value": {
    "uri": [
      "amqp://guest:guest@rabbit2",
      "amqp://guest:guest@rabbit3"
    ],
    "ack-mode": "on-confirm",
    "trust-user-id": false
  }
}
```

which results in the following response:

```json
[{
    "value": {
        "ack-mode": "on-confirm",
        "trust-user-id": false,
        "uri": ["amqp://guest:guest@rabbit2", "amqp://guest:guest@rabbit3"]
    },
    "vhost": "/",
    "component": "federation-upstream",
    "name": "multi-upstreams"
}, {
    "value": {
        "ack-mode": "on-confirm",
        "trust-user-id": false,
        "uri": "amqp://guest:guest@rabbit2"
    },
    "vhost": "/",
    "component": "federation-upstream",
    "name": "single-upstream"
}]


```

### Before the change

<img width="1156" alt="before" src="https://user-images.githubusercontent.com/709160/54763065-3335b180-4bed-11e9-9b68-98c38641c58c.png">

### After the change

<img width="1155" alt="after" src="https://user-images.githubusercontent.com/709160/54763325-b0612680-4bed-11e9-97e4-440c2676cb11.png">

## Types of Changes

What types of changes does your code introduce to this project?

- [X] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in related repositories