### PR TITLE
Catch failures when there is no user/vhost.

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -49,7 +49,7 @@
 -export([direct_request/6]).
 -export([qs_val/2]).
 -export([get_path_prefix/0]).
--export([catch_no_user_vhost/2]).
+-export([catch_no_such_user_or_vhost/2]).
 
 -import(rabbit_misc, [pget/2]).
 
@@ -1090,8 +1090,8 @@ qs_val(Name, ReqData) ->
     Qs = cowboy_req:parse_qs(ReqData),
     proplists:get_value(Name, Qs, undefined).
 
--spec catch_no_user_vhost(fun(() -> Result), Replacement) -> Result | Replacement.
-catch_no_user_vhost(Fun, Replacement) ->
+-spec catch_no_such_user_or_vhost(fun(() -> Result), Replacement) -> Result | Replacement.
+catch_no_such_user_or_vhost(Fun, Replacement) ->
     try
         Fun()
     catch throw:{error, {E, _}} when E =:= no_such_user; E =:= no_such_vhost ->

--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -49,6 +49,7 @@
 -export([direct_request/6]).
 -export([qs_val/2]).
 -export([get_path_prefix/0]).
+-export([catch_no_user_vhost/2]).
 
 -import(rabbit_misc, [pget/2]).
 
@@ -1088,3 +1089,11 @@ def(V, _) -> V.
 qs_val(Name, ReqData) ->
     Qs = cowboy_req:parse_qs(ReqData),
     proplists:get_value(Name, Qs, undefined).
+
+-spec catch_no_user_vhost(fun(() -> Result), Replacement) -> Result | Replacement.
+catch_no_user_vhost(Fun, Replacement) ->
+    try
+        Fun()
+    catch throw:{error, {E, _}} when E =:= no_such_user; E =:= no_such_vhost ->
+        Replacement()
+    end.

--- a/src/rabbit_mgmt_wm_permission.erl
+++ b/src/rabbit_mgmt_wm_permission.erl
@@ -88,7 +88,7 @@ perms(ReqData) ->
                 not_found ->
                     not_found;
                 VHost ->
-                    rabbit_mgmt_util:catch_no_user_vhost(
+                    rabbit_mgmt_util:catch_no_such_user_or_vhost(
                         fun() ->
                             Perms =
                                 rabbit_auth_backend_internal:list_user_vhost_permissions(

--- a/src/rabbit_mgmt_wm_permission.erl
+++ b/src/rabbit_mgmt_wm_permission.erl
@@ -88,15 +88,24 @@ perms(ReqData) ->
                 not_found ->
                     not_found;
                 VHost ->
-                    Perms =
-                        rabbit_auth_backend_internal:list_user_vhost_permissions(
-                          User, VHost),
-                    case Perms of
-                        [Rest] -> [{user,  User},
-                                   {vhost, VHost} | Rest];
-                        []     -> none
-                    end
+                    rabbit_mgmt_util:catch_no_user_vhost(
+                        fun() ->
+                            Perms =
+                                rabbit_auth_backend_internal:list_user_vhost_permissions(
+                                  User, VHost),
+                            case Perms of
+                                [Rest] -> [{user,  User},
+                                           {vhost, VHost} | Rest];
+                                []     -> none
+                            end
+                        end,
+                        fun() -> not_found end)
             end;
         {error, _} ->
             not_found
     end.
+
+
+
+
+

--- a/src/rabbit_mgmt_wm_permissions_user.erl
+++ b/src/rabbit_mgmt_wm_permissions_user.erl
@@ -42,7 +42,7 @@ resource_exists(ReqData, Context) ->
 
 to_json(ReqData, Context) ->
     User = rabbit_mgmt_util:id(user, ReqData),
-    rabbit_mgmt_util:catch_no_user_vhost(
+    rabbit_mgmt_util:catch_no_such_user_or_vhost(
         fun() ->
             Perms = rabbit_auth_backend_internal:list_user_permissions(User),
             rabbit_mgmt_util:reply_list([[{user, User} | Rest] || Rest <- Perms],

--- a/src/rabbit_mgmt_wm_permissions_user.erl
+++ b/src/rabbit_mgmt_wm_permissions_user.erl
@@ -42,9 +42,15 @@ resource_exists(ReqData, Context) ->
 
 to_json(ReqData, Context) ->
     User = rabbit_mgmt_util:id(user, ReqData),
-    Perms = rabbit_auth_backend_internal:list_user_permissions(User),
-    rabbit_mgmt_util:reply_list([[{user, User} | Rest] || Rest <- Perms],
-                                ["vhost", "user"], ReqData, Context).
+    rabbit_mgmt_util:catch_no_user_vhost(
+        fun() ->
+            Perms = rabbit_auth_backend_internal:list_user_permissions(User),
+            rabbit_mgmt_util:reply_list([[{user, User} | Rest] || Rest <- Perms],
+                                        ["vhost", "user"], ReqData, Context)
+        end,
+        fun() ->
+            rabbit_mgmt_util:bad_request(vhost_or_user_not_found, ReqData, Context)
+        end).
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized_admin(ReqData, Context).

--- a/src/rabbit_mgmt_wm_permissions_vhost.erl
+++ b/src/rabbit_mgmt_wm_permissions_vhost.erl
@@ -39,9 +39,15 @@ resource_exists(ReqData, Context) ->
 
 to_json(ReqData, Context) ->
     VHost = rabbit_mgmt_util:id(vhost, ReqData),
-    Perms = rabbit_auth_backend_internal:list_vhost_permissions(VHost),
-    rabbit_mgmt_util:reply_list([[{vhost, VHost} | Rest] || Rest <- Perms],
-                                ["vhost", "user"], ReqData, Context).
+    rabbit_mgmt_util:catch_no_user_vhost(
+        fun() ->
+            Perms = rabbit_auth_backend_internal:list_vhost_permissions(VHost),
+            rabbit_mgmt_util:reply_list([[{vhost, VHost} | Rest] || Rest <- Perms],
+                                        ["vhost", "user"], ReqData, Context)
+        end,
+        fun() ->
+            rabbit_mgmt_util:bad_request(vhost_or_user_not_found, ReqData, Context)
+        end).
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized_admin(ReqData, Context).

--- a/src/rabbit_mgmt_wm_permissions_vhost.erl
+++ b/src/rabbit_mgmt_wm_permissions_vhost.erl
@@ -39,7 +39,7 @@ resource_exists(ReqData, Context) ->
 
 to_json(ReqData, Context) ->
     VHost = rabbit_mgmt_util:id(vhost, ReqData),
-    rabbit_mgmt_util:catch_no_user_vhost(
+    rabbit_mgmt_util:catch_no_such_user_or_vhost(
         fun() ->
             Perms = rabbit_auth_backend_internal:list_vhost_permissions(VHost),
             rabbit_mgmt_util:reply_list([[{vhost, VHost} | Rest] || Rest <- Perms],

--- a/src/rabbit_mgmt_wm_topic_permission.erl
+++ b/src/rabbit_mgmt_wm_topic_permission.erl
@@ -94,14 +94,18 @@ topic_perms(ReqData) ->
                 not_found ->
                     not_found;
                 VHost ->
-                    Perms =
-                        rabbit_auth_backend_internal:list_user_vhost_topic_permissions(
-                          User, VHost),
-                    case Perms of
-                        []     -> none;
-                        TopicPermissions -> [[{user, User}, {vhost, VHost} | TopicPermission]
-                        || TopicPermission <- TopicPermissions]
-                    end
+                    rabbit_mgmt_util:catch_no_user_vhost(
+                        fun() ->
+                            Perms =
+                                rabbit_auth_backend_internal:list_user_vhost_topic_permissions(
+                                  User, VHost),
+                            case Perms of
+                                []     -> none;
+                                TopicPermissions -> [[{user, User}, {vhost, VHost} | TopicPermission]
+                                || TopicPermission <- TopicPermissions]
+                            end
+                        end,
+                        fun() -> not_found end)
             end;
         {error, _} ->
             not_found

--- a/src/rabbit_mgmt_wm_topic_permission.erl
+++ b/src/rabbit_mgmt_wm_topic_permission.erl
@@ -94,7 +94,7 @@ topic_perms(ReqData) ->
                 not_found ->
                     not_found;
                 VHost ->
-                    rabbit_mgmt_util:catch_no_user_vhost(
+                    rabbit_mgmt_util:catch_no_such_user_or_vhost(
                         fun() ->
                             Perms =
                                 rabbit_auth_backend_internal:list_user_vhost_topic_permissions(

--- a/src/rabbit_mgmt_wm_topic_permissions_user.erl
+++ b/src/rabbit_mgmt_wm_topic_permissions_user.erl
@@ -42,7 +42,7 @@ resource_exists(ReqData, Context) ->
 
 to_json(ReqData, Context) ->
     User = rabbit_mgmt_util:id(user, ReqData),
-    rabbit_mgmt_util:catch_no_user_vhost(
+    rabbit_mgmt_util:catch_no_such_user_or_vhost(
         fun() ->
             Perms = rabbit_auth_backend_internal:list_user_topic_permissions(User),
             rabbit_mgmt_util:reply_list([[{user, User} | Rest] || Rest <- Perms],

--- a/src/rabbit_mgmt_wm_topic_permissions_user.erl
+++ b/src/rabbit_mgmt_wm_topic_permissions_user.erl
@@ -42,9 +42,15 @@ resource_exists(ReqData, Context) ->
 
 to_json(ReqData, Context) ->
     User = rabbit_mgmt_util:id(user, ReqData),
-    Perms = rabbit_auth_backend_internal:list_user_topic_permissions(User),
-    rabbit_mgmt_util:reply_list([[{user, User} | Rest] || Rest <- Perms],
-                                ["vhost", "user"], ReqData, Context).
+    rabbit_mgmt_util:catch_no_user_vhost(
+        fun() ->
+            Perms = rabbit_auth_backend_internal:list_user_topic_permissions(User),
+            rabbit_mgmt_util:reply_list([[{user, User} | Rest] || Rest <- Perms],
+                                        ["vhost", "user"], ReqData, Context)
+        end,
+        fun() ->
+            rabbit_mgmt_util:bad_request(vhost_or_user_not_found, ReqData, Context)
+        end).
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized_admin(ReqData, Context).

--- a/src/rabbit_mgmt_wm_topic_permissions_vhost.erl
+++ b/src/rabbit_mgmt_wm_topic_permissions_vhost.erl
@@ -39,7 +39,7 @@ resource_exists(ReqData, Context) ->
 
 to_json(ReqData, Context) ->
     VHost = rabbit_mgmt_util:id(vhost, ReqData),
-    rabbit_mgmt_util:catch_no_user_vhost(
+    rabbit_mgmt_util:catch_no_such_user_or_vhost(
         fun() ->
             Perms = rabbit_auth_backend_internal:list_vhost_topic_permissions(VHost),
             rabbit_mgmt_util:reply_list([[{vhost, VHost} | Rest] || Rest <- Perms],

--- a/src/rabbit_mgmt_wm_topic_permissions_vhost.erl
+++ b/src/rabbit_mgmt_wm_topic_permissions_vhost.erl
@@ -39,9 +39,15 @@ resource_exists(ReqData, Context) ->
 
 to_json(ReqData, Context) ->
     VHost = rabbit_mgmt_util:id(vhost, ReqData),
-    Perms = rabbit_auth_backend_internal:list_vhost_topic_permissions(VHost),
-    rabbit_mgmt_util:reply_list([[{vhost, VHost} | Rest] || Rest <- Perms],
-                                ["vhost", "user"], ReqData, Context).
+    rabbit_mgmt_util:catch_no_user_vhost(
+        fun() ->
+            Perms = rabbit_auth_backend_internal:list_vhost_topic_permissions(VHost),
+            rabbit_mgmt_util:reply_list([[{vhost, VHost} | Rest] || Rest <- Perms],
+                                        ["vhost", "user"], ReqData, Context)
+        end,
+        fun() ->
+            rabbit_mgmt_util:bad_request(vhost_or_user_not_found, ReqData, Context)
+        end).
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized_admin(ReqData, Context).


### PR DESCRIPTION
## Proposed Changes

list_permissions operations may throw an exception if user/vhost
does not exist. Handlers use dirty_read to check for users/vhosts,
which is not enough if there is a concurrent deletion.
Return 404 instead of 500 in such cases.

To reproduce you need to start several applications, which will create users, list permissions and delete users.
List permission requests will sometimes fail with 500.
With this change they should fail with 404.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the mailing list. We're here to help! This is simply a reminder
of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
