### PR TITLE
Stop management application if metrics collection is disabled

### DIFF
--- a/src/rabbit_mgmt_app.erl
+++ b/src/rabbit_mgmt_app.erl
@@ -27,11 +27,16 @@
 -define(DEFAULT_PORT, 15672).
 
 start(_Type, _StartArgs) ->
-    %% Modern TCP listener uses management.tcp.*.
-    %% Legacy TCP (or TLS) listener uses management.listener.*.
-    %% Modern TLS listener uses management.ssl.*
-    start_configured_listener([], true),
-    rabbit_mgmt_sup_sup:start_link().
+    case application:get_env(rabbitmq_management_agent, disable_metrics_collector, false) of
+        false ->
+            %% Modern TCP listener uses management.tcp.*.
+            %% Legacy TCP (or TLS) listener uses management.listener.*.
+            %% Modern TLS listener uses management.ssl.*
+            start_configured_listener([], true),
+            rabbit_mgmt_sup_sup:start_link();
+        true ->
+            {error, "Metrics collection disabled in management agent"}
+    end.
 
 stop(_State) ->
     unregister_all_contexts(),


### PR DESCRIPTION
Depends on https://github.com/rabbitmq/rabbitmq-management-agent/pull/78

[#164376052]

## Types of Changes
- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the
discussion by explaining why you chose the solution you did and what
alternatives you considered, etc.
