### PR TITLE
Set msg rates in overview to global and basic in queue pages

### DIFF
--- a/priv/www/js/main.js
+++ b/priv/www/js/main.js
@@ -1589,7 +1589,13 @@ function get_chart_range_type(arg) {
     if (arg === 'lengths-over') {
         return 'global';
     }
+    if (arg === 'msg-rates-over') {
+        return 'global';
+    }
     if (arg === 'lengths-q') {
+        return 'basic';
+    }
+    if (arg === 'msg-rates-q') {
         return 'basic';
     }
     if (arg === 'queues') {


### PR DESCRIPTION
I can't think of a reason why we won't show the last 8/24h for message rates when they're available - same as message counters - instead of default to `basic`.

Also removes warning from the console, when we can easily set the default for all the known rates.

[#165377789]

## Types of Changes
- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

