### PR TITLE
Fix bytes prefix symbol

### DIFF
--- a/priv/www/js/formatters.js
+++ b/priv/www/js/formatters.js
@@ -311,7 +311,7 @@ function fmt_rate_axis(num, max) {
 
 function fmt_bytes(bytes) {
     if (bytes == undefined) return UNKNOWN_REPR;
-    return fmt_si_prefix(bytes, bytes, 1024, false) + 'B';
+    return fmt_si_prefix(bytes, bytes, 1024, false) + 'iB';
 }
 
 function fmt_bytes_axis(num, max) {


### PR DESCRIPTION
B is used for powers of 10, e.g. 10^6 bytes = 1MB
iB is used for powers of 2, e.g. 2^20 bytes = 1MiB

Since the division is using a power of 2, the symbol used also needs to
be a power of 2.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

This is somewhat related to rabbitmq/rabbitmq-server#1987

Before this change, 93048832 bytes were shown as 89MB. After this change, they are shown as 89MiB. This applies to all units:

![image](https://user-images.githubusercontent.com/3342/56594035-2806e480-65e4-11e9-863f-52a7265103a5.png)
