### PR TITLE
Add link to Management Stats doc

### DIFF
--- a/priv/www/js/tmpl/layout.ejs
+++ b/priv/www/js/tmpl/layout.ejs
@@ -35,6 +35,7 @@
 <div id="footer">
   <ul>
     <li><a href="api/" target="_blank">HTTP API</a></li>
+    <li><a href="stats/" target="_blank">HTTP Stats</a></li>
     <li><a href="https://www.rabbitmq.com/admin-guide.html" target="_blank">Server Docs</a></li>
     <li><a href="https://www.rabbitmq.com/getstarted.html" target="_blank">Tutorials</a></li>
     <li><a href="https://groups.google.com/forum/#!forum/rabbitmq-users" target="_blank">Community Support</a></li>

--- a/src/rabbit_mgmt_dispatcher.erl
+++ b/src/rabbit_mgmt_dispatcher.erl
@@ -29,14 +29,15 @@ build_routes(Ignore) ->
     ManagementApp = module_app(?MODULE),
     Prefix = rabbit_mgmt_util:get_path_prefix(),
     RootIdxRtes = build_root_index_routes(Prefix, ManagementApp),
-    ApiRdrRte = build_static_index_html_route(Prefix, "/api"),
-    CliRdrRte = build_static_index_html_route(Prefix, "/cli"),
+    ApiRdrRte = build_static_html_route("/api", Prefix ++ "/api/index.html"),
+    CliRdrRte = build_static_html_route("/cli", Prefix ++ "/cli/index.html"),
+    StatsRdrRte = build_static_html_route("/stats", Prefix ++ "/doc/stats.html"),
     MgmtRdrRte = {"/mgmt", rabbit_mgmt_wm_redirect, "/"},
     LocalPaths = [{module_app(M), "www"} || M <- modules(Ignore)],
     LocalStaticRte = {"/[...]", rabbit_mgmt_wm_static, LocalPaths},
     % NB: order is significant in the routing list
     Routes0 = build_module_routes(Ignore) ++
-        [ApiRdrRte, CliRdrRte, MgmtRdrRte, LocalStaticRte],
+        [ApiRdrRte, CliRdrRte, StatsRdrRte, MgmtRdrRte, LocalStaticRte],
     Routes1 = maybe_add_path_prefix(Routes0, Prefix),
     % NB: ensure the root routes are first
     Routes2 = RootIdxRtes ++ Routes1,
@@ -48,10 +49,8 @@ build_root_index_routes(Prefix, ManagementApp) ->
     [{"/", rabbit_mgmt_wm_redirect, Prefix ++ "/"},
      {Prefix, cowboy_static, root_idx_file(ManagementApp)}].
 
-build_static_index_html_route("", Path) ->
-    {Path, rabbit_mgmt_wm_redirect, Path ++ "/index.html"};
-build_static_index_html_route(Prefix, Path) ->
-    {Path, rabbit_mgmt_wm_redirect, Prefix ++ Path ++ "/index.html"}.
+build_static_html_route(Path, Location) ->
+    {Path, rabbit_mgmt_wm_redirect, Location}.
 
 root_idx_file(ManagementApp) ->
     {priv_file, ManagementApp, "www/index.html"}.

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -58,6 +58,7 @@ groups() ->
 all_tests() -> [
     cli_redirect_test,
     api_redirect_test,
+    stats_redirect_test,
     overview_test,
     auth_test,
     cluster_name_test,
@@ -2984,6 +2985,10 @@ cli_redirect_test(Config) ->
 
 api_redirect_test(Config) ->
     assert_permanent_redirect(Config, "api", "/api/index.html"),
+    passed.
+
+stats_redirect_test(Config) ->
+    assert_permanent_redirect(Config, "stats", "/doc/stats.html"),
     passed.
 
 %% -------------------------------------------------------------------


### PR DESCRIPTION
I found it most useful while working on rabbitmq_prometheus, I think
others will appreciate knowing about it too. There was no link to it on
management, there is a single reference to this document on the website,
introduced in #427.

* https://github.com/rabbitmq/rabbitmq-website/blame/433eec2476ca691616efc17d5dc0bd3abe9bb8be/site/monitoring.md#L227

![image](https://user-images.githubusercontent.com/3342/56617290-71bcf280-6617-11e9-89f0-b568c5ed1cd0.png)

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories