### PR TITLE
Expose pending raft command metric

### DIFF
--- a/priv/www/js/tmpl/channel.ejs
+++ b/priv/www/js/tmpl/channel.ejs
@@ -63,6 +63,13 @@
   </tr>
 </table>
 
+<table class="facts">
+  <tr>
+    <th>Pending Raft commands</th>
+    <td><%= channel.pending_raft_commands %></td>
+  </tr>
+</table>
+
 </div>
 </div>
 


### PR DESCRIPTION
On channel page


Requires: https://github.com/rabbitmq/rabbitmq-server/pull/2022