### PR TITLE
Definitions import timeout

### DIFF
--- a/src/rabbit_mgmt_load_definitions.erl
+++ b/src/rabbit_mgmt_load_definitions.erl
@@ -74,4 +74,7 @@ load_definitions_from_file(File) ->
 
 load_definitions(Body) ->
     rabbit_mgmt_wm_definitions:apply_defs(
-      Body, ?INTERNAL_USER, fun () -> ok end, fun (E) -> {error, E} end).
+        Body, ?INTERNAL_USER,
+        fun () -> ok end,
+        fun (E) -> {error, E} end,
+        fun (_Msg) -> ok end).

--- a/src/rabbit_mgmt_wm_definitions.erl
+++ b/src/rabbit_mgmt_wm_definitions.erl
@@ -21,7 +21,7 @@
 -export([accept_multipart/2]).
 -export([variances/2]).
 
--export([apply_defs/4]).
+-export([apply_defs/5]).
 
 -import(rabbit_misc, [pget/2]).
 
@@ -155,23 +155,35 @@ accept(Body, ReqData, Context = #context{user = #user{username = Username}}) ->
     %% At this point the request was fully received.
     %% There is no point in the idle_timeout anymore.
     disable_idle_timeout(ReqData),
+    SuccessFun =
+        fun() ->
+            {true, ReqData, Context}
+        end,
+    ErrorFun =
+        fun(E) ->
+            rabbit_mgmt_util:bad_request(E, ReqData, Context)
+        end,
+    ProgressFun =
+        fun(Message) ->
+            ok = cowboy_req:inform(102,
+                                   #{<<"x-rabbitmq-import-progress">> =>
+                                         rabbit_data_coercion:to_binary(Message)},
+                                   ReqData)
+        end,
     case rabbit_mgmt_util:vhost(ReqData) of
         none ->
-            apply_defs(Body, Username, fun() -> {true, ReqData, Context} end,
-                       fun(E) -> rabbit_mgmt_util:bad_request(E, ReqData, Context) end);
+            apply_defs(Body, Username, SuccessFun, ErrorFun, ProgressFun);
         not_found ->
             rabbit_mgmt_util:bad_request(rabbit_data_coercion:to_binary("vhost_not_found"),
                                          ReqData, Context);
         VHost ->
-            apply_defs(Body, Username, fun() -> {true, ReqData, Context} end,
-                       fun(E) -> rabbit_mgmt_util:bad_request(E, ReqData, Context) end,
-                       VHost)
+            apply_defs(Body, Username, SuccessFun, ErrorFun, ProgressFun, VHost)
     end.
 
 disable_idle_timeout(#{pid := Pid, streamid := StreamID}) ->
     Pid ! {{Pid, StreamID}, {set_options, #{idle_timeout => infinity}}}.
 
-apply_defs(Body, ActingUser, SuccessFun, ErrorFun) ->
+apply_defs(Body, ActingUser, SuccessFun, ErrorFun, ProgressFun) ->
     rabbit_log:info("Asked to import definitions. Acting user: ~s", [rabbit_data_coercion:to_binary(ActingUser)]),
     case rabbit_mgmt_util:decode([], Body) of
         {error, E} ->
@@ -179,7 +191,7 @@ apply_defs(Body, ActingUser, SuccessFun, ErrorFun) ->
         {ok, _, All} ->
             Version = maps:get(rabbit_version, All, undefined),
             try
-                rabbit_log:info("Importing users..."),
+                progress(ProgressFun, "Importing users..."),
                 for_all(users,              ActingUser, All,
                         fun(User, _Username) ->
                                 rabbit_mgmt_wm_user:put_user(
@@ -187,24 +199,24 @@ apply_defs(Body, ActingUser, SuccessFun, ErrorFun) ->
                                   Version,
                                   ActingUser)
                         end),
-                rabbit_log:info("Importing vhosts..."),
+                progress(ProgressFun, "Importing vhosts..."),
                 for_all(vhosts,             ActingUser, All, fun add_vhost/2),
                 validate_limits(All),
-                rabbit_log:info("Importing user permissions..."),
+                progress(ProgressFun, "Importing user permissions..."),
                 for_all(permissions,        ActingUser, All, fun add_permission/2),
-                rabbit_log:info("Importing topic permissions..."),
+                progress(ProgressFun, "Importing topic permissions..."),
                 for_all(topic_permissions,  ActingUser, All, fun add_topic_permission/2),
-                rabbit_log:info("Importing parameters..."),
+                progress(ProgressFun, "Importing parameters..."),
                 for_all(parameters,         ActingUser, All, fun add_parameter/2),
-                rabbit_log:info("Importing global parameters..."),
+                progress(ProgressFun, "Importing global parameters..."),
                 for_all(global_parameters,  ActingUser, All, fun add_global_parameter/2),
-                rabbit_log:info("Importing policies..."),
+                progress(ProgressFun, "Importing policies..."),
                 for_all(policies,           ActingUser, All, fun add_policy/2),
-                rabbit_log:info("Importing queues..."),
+                progress(ProgressFun, "Importing queues..."),
                 for_all(queues,             ActingUser, All, fun add_queue/2),
-                rabbit_log:info("Importing exchanges..."),
+                progress(ProgressFun, "Importing exchanges..."),
                 for_all(exchanges,          ActingUser, All, fun add_exchange/2),
-                rabbit_log:info("Importing bindings..."),
+                progress(ProgressFun, "Importing bindings..."),
                 for_all(bindings,           ActingUser, All, fun add_binding/2),
                 SuccessFun()
             catch {error, E} -> ErrorFun(format(E));
@@ -212,29 +224,34 @@ apply_defs(Body, ActingUser, SuccessFun, ErrorFun) ->
             end
     end.
 
-apply_defs(Body, ActingUser, SuccessFun, ErrorFun, VHost) ->
-    rabbit_log:info("Asked to import definitions. Acting user: ~p", [ActingUser]),
+apply_defs(Body, ActingUser, SuccessFun, ErrorFun, ProgressFun, VHost) ->
+    rabbit_log:info("Asked to import vhost definitions. Vhost: ~p Acting user: ~p",
+                    [VHost, ActingUser]),
     case rabbit_mgmt_util:decode([], Body) of
         {error, E} ->
             ErrorFun(E);
         {ok, _, All} ->
             try
                 validate_limits(All, VHost),
-                rabbit_log:info("Importing parameters..."),
+                progress(ProgressFun, "Importing parameters..."),
                 for_all(parameters,  ActingUser, All, VHost, fun add_parameter/3),
-                rabbit_log:info("Importing policies..."),
+                progress(ProgressFun, "Importing policies..."),
                 for_all(policies,    ActingUser, All, VHost, fun add_policy/3),
-                rabbit_log:info("Importing queues..."),
+                progress(ProgressFun, "Importing queues..."),
                 for_all(queues,      ActingUser, All, VHost, fun add_queue/3),
-                rabbit_log:info("Importing exchanges..."),
+                progress(ProgressFun, "Importing exchanges..."),
                 for_all(exchanges,   ActingUser, All, VHost, fun add_exchange/3),
-                rabbit_log:info("Importing bindings..."),
+                progress(ProgressFun, "Importing bindings..."),
                 for_all(bindings,    ActingUser, All, VHost, fun add_binding/3),
                 SuccessFun()
             catch {error, E} -> ErrorFun(format(E));
                   exit:E     -> ErrorFun(format(E))
             end
     end.
+
+progress(ProgressFun, Message) ->
+    rabbit_log:info(Message),
+    ProgressFun(Message).
 
 format(#amqp_error{name = Name, explanation = Explanation}) ->
     rabbit_data_coercion:to_binary(rabbit_misc:format("~s: ~s", [Name, Explanation]));

--- a/src/rabbit_mgmt_wm_definitions.erl
+++ b/src/rabbit_mgmt_wm_definitions.erl
@@ -225,7 +225,7 @@ apply_defs(Body, ActingUser, SuccessFun, ErrorFun, ProgressFun) ->
     end.
 
 apply_defs(Body, ActingUser, SuccessFun, ErrorFun, ProgressFun, VHost) ->
-    rabbit_log:info("Asked to import vhost definitions. Vhost: ~p Acting user: ~p",
+    rabbit_log:info("Asked to import definitions for a virtual host. Virtual host: ~p, acting user: ~p",
                     [VHost, ActingUser]),
     case rabbit_mgmt_util:decode([], Body) of
         {error, E} ->

--- a/test/definitions_import_SUITE.erl
+++ b/test/definitions_import_SUITE.erl
@@ -121,4 +121,5 @@ run_import_case(Path) ->
    rabbit_mgmt_wm_definitions:apply_defs(Body, ?INTERNAL_USER,
                                          fun ()  -> ct:pal("Import case ~p succeeded~n",  [Path]) end,
                                          fun (E) -> ct:pal("Import case ~p failed: ~p~n", [Path, E]),
-                                                    ct:fail({failure, Path, E}) end).
+                                                    ct:fail({failure, Path, E}) end,
+                                         fun (Msg) -> ct:pal("Import progress: ~p~n", [Msg]) end).

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -1575,7 +1575,7 @@ long_definitions_test(Config) ->
 
 long_definitions_vhosts() ->
     [#{name => <<"long_definitions_test-", (integer_to_binary(N))/binary>>}
-     || N <- lists:seq(1, 500)].
+     || N <- lists:seq(1, 120)].
 
 defs_vhost(Config, Key, URI, CreateMethod, Args) ->
     Rep1 = fun (S, S2) -> re:replace(S, "<vhost>", S2, [{return, list}]) end,


### PR DESCRIPTION
## Proposed Changes

When importing long definitions file, the request may fail silently due to `idle_timeout` in cowboy. [1](https://ninenines.eu/docs/en/cowboy/2.0/manual/cowboy_http/)
This timeout terminates the connection process silently without any logs.
The default timeout is 60 seconds and setting it in the configuration will impact all other requests, which is undesirable because the HTTP client can fail and there will be zombie processes. [2](https://github.com/ninenines/cowboy/issues/1278)

For the definitions import it's expected that it may take long time, therefore this PR notifies the cowboy stream process that the timeout should be disabled.
This is done after entire request body is received and should not lead to zombie processes, because the request does not wait for the client after that point.

Also added process reports, sent with HTTP 102 messages to prevent clients from timing out and closing the connection.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the mailing list. We're here to help! This is simply a reminder
of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Open questions:
- I'm not sure that infinity is the best value here, maybe just a large integer would be better.
- I didn't find and API to set the timeout from the request handler, the API I used is a bit hacky. @essen is there a better way to do that?
