### PR TITLE
Group policy parameters by queue type

### DIFF
--- a/priv/www/js/global.js
+++ b/priv/www/js/global.js
@@ -189,7 +189,7 @@ var HELP = {
       'Set the queue into lazy mode, keeping as many messages as possible on disk to reduce RAM usage; if not set, the queue will keep an in-memory cache to deliver messages as fast as possible.<br/>(Sets the "<a target="_blank" href="https://www.rabbitmq.com/lazy-queues.html">x-queue-mode</a>" argument.)',
 
     'queue-overflow':
-      'Sets the <a target="_blank" href="https://www.rabbitmq.com/maxlength.html#overflow-behaviour">queue overflow behaviour</a>. This determines what happens to messages when the maximum length of a queue is reached. Valid values are <code>drop-head</code>, <code>reject-publish</code> or <code>reject-publish-dlx</code>.',
+      'Sets the <a target="_blank" href="https://www.rabbitmq.com/maxlength.html#overflow-behaviour">queue overflow behaviour</a>. This determines what happens to messages when the maximum length of a queue is reached. Valid values are <code>drop-head</code>, <code>reject-publish</code> or <code>reject-publish-dlx</code>. The quorum queue type only supports <code>drop-head</code>.',
 
     'queue-master-locator':
        'Set the queue into master location mode, determining the rule by which the queue master is located when declared on a cluster of nodes.<br/>(Sets the "<a target="_blank" href="https://www.rabbitmq.com/ha.html">x-queue-master-locator</a>" argument.)',

--- a/priv/www/js/tmpl/policies.ejs
+++ b/priv/www/js/tmpl/policies.ejs
@@ -96,35 +96,37 @@
             <div class="multifield" id="definition"></div>
             <table class="argument-links">
               <tr>
-                <td>HA</td>
+                  <td>Queues [All types]</td>
+                <td>
+                  <span class="argument-link" field="definition" key="max-length" type="number">Max length</span> |
+                  <span class="argument-link" field="definition" key="max-length-bytes" type="number">Max length bytes</span> |
+                  <span class="argument-link" field="definition" key="overflow" type="string">Overflow behaviour</span>
+                  <span class="help" id="queue-overflow"></span> </br>
+                  <span class="argument-link" field="definition" key="dead-letter-exchange" type="string">Dead letter exchange</span> |
+                  <span class="argument-link" field="definition" key="dead-letter-routing-key" type="string">Dead letter routing key</span><br />
+                </td>
+              <tr>
+                <td>Queues [Classic]</td>
                 <td>
                   <span class="argument-link" field="definition" key="ha-mode" type="string">HA mode</span> <span class="help" id="policy-ha-mode"></span> |
                   <span class="argument-link" field="definition" key="ha-params" type="number">HA params</span> <span class="help" id="policy-ha-params"></span> |
-                  <span class="argument-link" field="definition" key="ha-sync-mode" type="string">HA sync mode</span> <span class="help" id="policy-ha-sync-mode"></span> |
-                  <span class="argument-link" field="definition" key="ha-promote-on-shutdown" type="string" value="">HA mirror promotion on shutdown</span> <span class="help" id="policy-ha-promote-on-shutdown"></span>
+                  <span class="argument-link" field="definition" key="ha-sync-mode" type="string">HA sync mode</span> <span class="help" id="policy-ha-sync-mode"></span> </br>
+                  <span class="argument-link" field="definition" key="ha-promote-on-shutdown" type="string" value="">HA mirror promotion on shutdown</span> <span class="help" id="policy-ha-promote-on-shutdown"></span> |
                   <span class="argument-link" field="definition" key="ha-promote-on-failure" type="string" value="">HA mirror promotion on failure</span> <span class="help" id="policy-ha-promote-on-failure"></span>
-                </td>
-              </tr>
-              <tr>
-                <td>Federation</td>
-                <td>
-                  <span class="argument-link" field="definition" key="federation-upstream-set" type="string">Federation upstream set</span> <span class="help" id="policy-federation-upstream-set"></span> |
-                  <span class="argument-link" field="definition" key="federation-upstream" type="string">Federation upstream</span>
-                  <span class="help" id="policy-federation-upstream"></span>
-                </td>
-              </tr>
-              <tr>
-                <td>Queues</td>
-                <td>
+                  </br>
                   <span class="argument-link" field="definition" key="message-ttl" type="number">Message TTL</span> |
                   <span class="argument-link" field="definition" key="expires" type="number">Auto expire</span> |
-                  <span class="argument-link" field="definition" key="max-length" type="number">Max length</span> |
-                  <span class="argument-link" field="definition" key="max-length-bytes" type="number">Max length bytes</span> |
-                  <span class="argument-link" field="definition" key="overflow" type="string">Overflow behaviour</span><br/>
-                  <span class="argument-link" field="definition" key="dead-letter-exchange" type="string">Dead letter exchange</span> |
-                  <span class="argument-link" field="definition" key="dead-letter-routing-key" type="string">Dead letter routing key</span><br />
                   <span class="argument-link" field="definition" key="queue-mode" type="string" value="lazy">Lazy mode</span> |
                   <span class="argument-link" field="definition" key="queue-master-locator" type="string">Master Locator</span></br>
+                </td>
+              </tr>
+              <tr>
+                <td>Queues [Quorum]</td>
+                <td>
+                  <span class="argument-link" field="definition" key="max-in-memory-length" type="number">Max in memory length</span>
+                  <span class="help" id="queue-max-in-memory-length"></span> |
+                  <span class="argument-link" field="definition" key="max-in-memory-bytes" type="number">Max in memory bytes</span>
+                  <span class="help" id="queue-max-in-memory-bytes"></span> |
                   <span class="argument-link" field="definition" key="delivery-limit" type="number">Delivery limit</span>
                   <span class="help" id="delivery-limit"></span>
                 </td>
@@ -134,6 +136,14 @@
                 <td>
                   <span class="argument-link" field="definition" key="alternate-exchange" type="string">Alternate exchange</span>
                   <span class="help" id="exchange-alternate"></span>
+                </td>
+              </tr>
+              <tr>
+                <td>Federation</td>
+                <td>
+                  <span class="argument-link" field="definition" key="federation-upstream-set" type="string">Federation upstream set</span> <span class="help" id="policy-federation-upstream-set"></span> |
+                  <span class="argument-link" field="definition" key="federation-upstream" type="string">Federation upstream</span>
+                  <span class="help" id="policy-federation-upstream"></span>
                 </td>
               </tr>
             </table>
@@ -247,13 +257,28 @@
             <div class="multifield" id="definitionop"></div>
             <table class="argument-links">
               <tr>
-                <td>Queues</td>
+                <td>Queues [All types]</td>
                 <td>
-                  <span class="argument-link" field="definitionop" key="message-ttl" type="number">Message TTL</span> |
-                  <span class="argument-link" field="definitionop" key="expires" type="number">Auto expire</span> |
                   <span class="argument-link" field="definitionop" key="max-length" type="number">Max length</span> |
                   <span class="argument-link" field="definitionop" key="max-length-bytes" type="number">Max length bytes</span> |
-                  <span class="argument-link" field="definitionop" key="overflow" type="string">Overflow behaviour</span><br/>
+                  <span class="argument-link" field="definitionop" key="overflow" type="string">Overflow behaviour</span>
+                  <span class="help" id="queue-overflow"></span>
+                </td>
+              </tr>
+              <tr>
+                <td>Queues [Classic]</td>
+                <td>
+                  <span class="argument-link" field="definitionop" key="message-ttl" type="number">Message TTL</span> |
+                  <span class="argument-link" field="definitionop" key="expires" type="number">Auto expire</span>
+                </td>
+              </tr>
+              <tr>
+                <td>Queues [Quorum]</td>
+                <td>
+                  <span class="argument-link" field="definitionop" key="max-in-memory-length" type="number">Max in memory length</span>
+                  <span class="help" id="queue-max-in-memory-length"></span> |
+                  <span class="argument-link" field="definitionop" key="max-in-memory-bytes" type="number">Max in memory bytes</span>
+                  <span class="help" id="queue-max-in-memory-bytes"></span> |
                   <span class="argument-link" field="definitionop" key="delivery-limit" type="string">Delivery limit</span>
                   <span class="help" id="delivery-limit"></span>
                 </td>


### PR DESCRIPTION
As some policy parameters only applies to certain queue types this
change groups them by the queue types they apply to which makes it
clearer for the users to see which parameters apply where.
