### PR TITLE
Highlight leading and trailing white space in names

### DIFF
--- a/priv/www/js/formatters.js
+++ b/priv/www/js/formatters.js
@@ -6,7 +6,8 @@ const SOCKETS_THRESHOLDS = [[1.0, 'red'],
 const PROCESS_THRESHOLDS = [[0.75, 'red'],
                             [0.5, 'yellow']];
 
-const WHITESPACE_HIGHLIGHTER = "\u23B5"
+const TAB_HIGHLIGHTER = "\u2192";
+const WHITESPACE_HIGHLIGHTER = "\u23B5";
 
 function fmt_string(str, unknown) {
     if (unknown == undefined) {
@@ -684,9 +685,47 @@ function esc(str) {
     return encodeURIComponent(str);
 }
 
+// Replaces a sequence of characters matched by a regular expression
+// group with the given character. Replaced group is combined with the stripped
+// original using the provided combine function.
+function replace_char_sequence_individually(input, regex, replacement, combine) {
+  let ms = input.match(regex);
+    if (ms == null) {
+      return input;
+    } else {
+      let n = ms[0].length;
+      return combine(replacement.repeat(n), input.replace(regex, ""));
+    }
+}
+
+// Replaces a leading sequence of characters matched by a regular expression
+// group with the given character.
+function replace_leading_chars(input, regex, replacement) {
+  return replace_char_sequence_individually(input, regex, replacement, function(patch, stripped_input) {
+      return patch + stripped_input;
+  });
+}
+
+// Replaces a trailing sequence of characters matched by a regular expression
+// group with the given character.
+function replace_trailing_chars(input, regex, replacement) {
+    return replace_char_sequence_individually(input, regex, replacement, function(patch, stripped_input) {
+      return stripped_input + patch;
+  });
+}
+
+// Highlights extra (leading and trailing) whitespace and tab characters
+// with suitable Unicode characters for improved visiblity.
+// Note that mid-word whitespace should not be highighted, which makes
+// the implementation trickier than a simple chain of replace/2 calls.
 function highlight_extra_whitespace(str) {
-  return str.replace(/^\s+/g, WHITESPACE_HIGHLIGHTER).
-             replace(/\s+$/g, WHITESPACE_HIGHLIGHTER);
+  // Highlight leading and trailing whitespace individually but all tabs.
+  // This assumes that spaces are reasonable to use in the middle of a name
+  // but tabs are not used intentionally and must be highlighted even in the middle.
+  return [[replace_trailing_chars, /(\s+)$/g, WHITESPACE_HIGHLIGHTER],
+          [replace_leading_chars,  /^(\s+)/g, WHITESPACE_HIGHLIGHTER]].reduce(function(acc, triplet) {
+    return triplet[0](acc, triplet[1], triplet[2]);
+  }, str.replace(/\t/g, TAB_HIGHLIGHTER));
 }
 
 function link_conn(name, desc) {

--- a/priv/www/js/formatters.js
+++ b/priv/www/js/formatters.js
@@ -1,10 +1,12 @@
-UNKNOWN_REPR = '<span class="unknown">?</span>';
-FD_THRESHOLDS=[[0.95, 'red'],
-               [0.8, 'yellow']];
-SOCKETS_THRESHOLDS=[[1.0, 'red'],
-                    [0.8, 'yellow']];
-PROCESS_THRESHOLDS=[[0.75, 'red'],
-                    [0.5, 'yellow']];
+const UNKNOWN_REPR = '<span class="unknown">?</span>';
+const FD_THRESHOLDS = [[0.95, 'red'],
+                       [0.8, 'yellow']];
+const SOCKETS_THRESHOLDS = [[1.0, 'red'],
+                            [0.8, 'yellow']];
+const PROCESS_THRESHOLDS = [[0.75, 'red'],
+                            [0.5, 'yellow']];
+
+const WHITESPACE_HIGHLIGHTER = "\u23B5"
 
 function fmt_string(str, unknown) {
     if (unknown == undefined) {
@@ -682,6 +684,11 @@ function esc(str) {
     return encodeURIComponent(str);
 }
 
+function highlight_extra_whitespace(str) {
+  return str.replace(/^\s+/g, WHITESPACE_HIGHLIGHTER).
+             replace(/\s+$/g, WHITESPACE_HIGHLIGHTER);
+}
+
 function link_conn(name, desc) {
     if (desc == undefined) {
         return _link_to(short_conn(name), '#/connections/' + esc(name));
@@ -697,11 +704,11 @@ function link_channel(name) {
 
 function link_exchange(vhost, name, args) {
     var url = esc(vhost) + '/' + (name == '' ? 'amq.default' : esc(name));
-    return _link_to(fmt_exchange0(name), '#/exchanges/' + url, true, args);
+    return _link_to(fmt_exchange0(highlight_extra_whitespace(name), '#/exchanges/' + url, true, args));
 }
 
 function link_queue(vhost, name, args) {
-    return _link_to(name, '#/queues/' + esc(vhost) + '/' + esc(name), true, args);
+    return _link_to(highlight_extra_whitespace(name), '#/queues/' + esc(vhost) + '/' + esc(name), true, args);
 }
 
 function link_vhost(name) {

--- a/priv/www/js/tmpl/exchange.ejs
+++ b/priv/www/js/tmpl/exchange.ejs
@@ -1,4 +1,4 @@
-<h1>Exchange: <b><%= fmt_exchange(exchange.name) %></b><%= fmt_maybe_vhost(exchange.vhost) %></h1>
+<h1>Exchange: <b><%= fmt_exchange(highlight_extra_whitespace(exchange.name)) %></b><%= fmt_maybe_vhost(exchange.vhost) %></h1>
 
 <div class="section">
   <h2>Overview</h2>

--- a/priv/www/js/tmpl/queue.ejs
+++ b/priv/www/js/tmpl/queue.ejs
@@ -1,4 +1,4 @@
-<h1>Queue <b><%= fmt_string(queue.name) %></b><%= fmt_maybe_vhost(queue.vhost) %></h1>
+<h1>Queue <b><%= fmt_string(highlight_extra_whitespace(queue.name)) %></b><%= fmt_maybe_vhost(queue.vhost) %></h1>
 
 <% if(!disable_stats) { %>
 <div class="section">


### PR DESCRIPTION
## Proposed Changes

Names with leading and trailing white space are almost always
a mistake and cause confusion. In a recent support
case they wasted quite a bit of time.

Currently leading and trailing white space in names is very difficult to spot as both management UI
and CLI tools do not highlight white space in names in any way.

This introduces highlighting of leading and trailing white space in queue and exchange names.
Only leading and trailing white spaces, new line characters, vertical tabs and other matches of `\s` are highlighted, each with a highlighting character. Tabs are highlighted everywhere in the name,
including in the middle. This assumes that tabs are only used in names by mistake (unlike spaces).

The highlighting character is chosen to be the `⎵` character (Unicode character code: `U+23B5`) per discussion with the team: it is quite visible on all kinds of screens and would be more obvious than `·` (`U+00B7`) and some other options used by developer-oriented tools.

Here's an [excellent thread that discusses various options](https://ux.stackexchange.com/questions/91255/how-can-i-best-display-a-blank-space-character).

This screenshot provides a rough idea of what it looks like:

![Screenshot_2019-07-21 RabbitMQ Management](https://user-images.githubusercontent.com/1090/61587784-0ee8e200-ab99-11e9-949d-560d59512788.png)

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

[#167415546]