### PR TITLE
 Parse routing keys with values of `null` and `undefined` to their respective atoms

### DIFF
--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -92,6 +92,7 @@ all_tests() -> [
     queues_well_formed_json_test,
     bindings_test,
     bindings_post_test,
+    bindings_null_routing_key_test,
     bindings_e2e_test,
     permissions_administrator_test,
     permissions_vhost_test,
@@ -1102,13 +1103,13 @@ bindings_post_test(Config) ->
     http_post(Config, "/bindings/%2F/e/badexchange/q/myqueue", BArgs, ?NOT_FOUND),
 
     Headers1 = http_post(Config, "/bindings/%2F/e/myexchange/q/myqueue", #{}, {group, '2xx'}),
-    Want0 = "myqueue/~",
+    Want0 = "myqueue/\~",
     ?assertEqual(Want0, pget("location", Headers1)),
 
     Headers2 = http_post(Config, "/bindings/%2F/e/myexchange/q/myqueue", BArgs, {group, '2xx'}),
     %% Args hash is calculated from a table, generated from args.
     Hash = table_hash([{<<"foo">>,longstr,<<"bar">>}]),
-    PropertiesKey = "routing~" ++ Hash,
+    PropertiesKey = "routing\~" ++ Hash,
 
     Want1 = "myqueue/" ++ PropertiesKey,
     ?assertEqual(Want1, pget("location", Headers2)),
@@ -1126,6 +1127,44 @@ bindings_post_test(Config) ->
 
     http_get(Config, URI ++ "x", ?NOT_FOUND),
     http_delete(Config, URI, {group, '2xx'}),
+    http_delete(Config, "/exchanges/%2F/myexchange", {group, '2xx'}),
+    http_delete(Config, "/queues/%2F/myqueue", {group, '2xx'}),
+    passed.
+
+bindings_null_routing_key_test(Config) ->
+    XArgs = [{type, <<"direct">>}],
+    QArgs = #{},
+    BArgs = [{routing_key, null}, {arguments, #{}}],
+    http_put(Config, "/exchanges/%2F/myexchange", XArgs, {group, '2xx'}),
+    http_put(Config, "/queues/%2F/myqueue", QArgs, {group, '2xx'}),
+    http_post(Config, "/bindings/%2F/e/myexchange/q/badqueue", BArgs, ?NOT_FOUND),
+    http_post(Config, "/bindings/%2F/e/badexchange/q/myqueue", BArgs, ?NOT_FOUND),
+
+    Headers1 = http_post(Config, "/bindings/%2F/e/myexchange/q/myqueue", #{}, {group, '2xx'}),
+    Want0 = "myqueue/\~",
+    ?assertEqual(Want0, pget("location", Headers1)),
+
+    Headers2 = http_post(Config, "/bindings/%2F/e/myexchange/q/myqueue", BArgs, {group, '2xx'}),
+    %% Args hash is calculated from a table, generated from args.
+    Hash = table_hash([]),
+    PropertiesKey = "null\~" ++ Hash,
+
+    ?assertEqual("myqueue/null", pget("location", Headers2)),
+
+    PropertiesKeyBin = list_to_binary(PropertiesKey),
+    Want2 = #{arguments => #{},
+              destination => <<"myqueue">>,
+              destination_type => <<"queue">>,
+              properties_key => <<"null">>,
+              routing_key => null,
+              source => <<"myexchange">>,
+              vhost => <<"/">>},
+    URI = "/bindings/%2F/e/myexchange/q/myqueue/" ++ PropertiesKey,
+    ?assertEqual(Want2, http_get(Config, URI, ?OK)),
+
+    http_get(Config, URI ++ "x", ?NOT_FOUND),
+    http_delete(Config, URI, {group, '2xx'}),
+    http_delete(Config, "/bindings/%2F/e/myexchange/q/myqueue/" ++ PropertiesKey, {group, '2xx'}),
     http_delete(Config, "/exchanges/%2F/myexchange", {group, '2xx'}),
     http_delete(Config, "/queues/%2F/myqueue", {group, '2xx'}),
     passed.

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -1132,6 +1132,7 @@ bindings_post_test(Config) ->
     passed.
 
 bindings_null_routing_key_test(Config) ->
+    http_delete(Config, "/exchanges/%2F/myexchange", {one_of, [201, 404]}),
     XArgs = [{type, <<"direct">>}],
     QArgs = #{},
     BArgs = [{routing_key, null}, {arguments, #{}}],
@@ -1150,9 +1151,7 @@ bindings_null_routing_key_test(Config) ->
     PropertiesKey = "null\~" ++ Hash,
 
     ?assertEqual("myqueue/null", pget("location", Headers2)),
-
-    PropertiesKeyBin = list_to_binary(PropertiesKey),
-    Want2 = #{arguments => #{},
+    Want1 = #{arguments => #{},
               destination => <<"myqueue">>,
               destination_type => <<"queue">>,
               properties_key => <<"null">>,
@@ -1160,11 +1159,10 @@ bindings_null_routing_key_test(Config) ->
               source => <<"myexchange">>,
               vhost => <<"/">>},
     URI = "/bindings/%2F/e/myexchange/q/myqueue/" ++ PropertiesKey,
-    ?assertEqual(Want2, http_get(Config, URI, ?OK)),
+    ?assertEqual(Want1, http_get(Config, URI, ?OK)),
 
     http_get(Config, URI ++ "x", ?NOT_FOUND),
     http_delete(Config, URI, {group, '2xx'}),
-    http_delete(Config, "/bindings/%2F/e/myexchange/q/myqueue/" ++ PropertiesKey, {group, '2xx'}),
     http_delete(Config, "/exchanges/%2F/myexchange", {group, '2xx'}),
     http_delete(Config, "/queues/%2F/myqueue", {group, '2xx'}),
     passed.
@@ -1817,6 +1815,7 @@ arguments_test(Config) ->
     BArgs = [{routing_key, <<"">>},
              {arguments, [{'x-match', <<"all">>},
                           {foo, <<"bar">>}]}],
+    http_delete(Config, "/exchanges/%2F/myexchange", {one_of, [201, 404]}),
     http_put(Config, "/exchanges/%2F/myexchange", XArgs, {group, '2xx'}),
     http_put(Config, "/queues/%2F/arguments_test", QArgs, {group, '2xx'}),
     http_post(Config, "/bindings/%2F/e/myexchange/q/arguments_test", BArgs, {group, '2xx'}),
@@ -1851,6 +1850,7 @@ arguments_table_test(Config) ->
                              <<"amqp://localhost/%2F/upstream2">>]},
     XArgs = #{type      => <<"headers">>,
               arguments => Args},
+    http_delete(Config, "/exchanges/%2F/myexchange", {one_of, [201, 404]}),
     http_put(Config, "/exchanges/%2F/myexchange", XArgs, {group, '2xx'}),
     Definitions = http_get(Config, "/definitions", ?OK),
     http_delete(Config, "/exchanges/%2F/myexchange", {group, '2xx'}),


### PR DESCRIPTION
See #723 for background.

Currently there are three main ways to declare a binding:

 * Use an AMQP 0-9-1 client
 * Use an HTTP API client
 * Definition import

For the sake of this change we will fold the latter two options into
one as they are effectively identical as far as data formats go.

An HTTP API client can do things that an AMQP 0-9-1 would not be able
to because of framing/parser/generator restrictions, and vice versa.

With HTTP API and definition import the following importance

 * When a binding is added, routing key can be omitted or set to `null` 
(or `undefined`)
 * When a binding is deleted, a blank routing key can only be specified
   using a convention since an empty URI path arguments are not 
supported
   by Cowboy REST and would make no sense to the developer.

Omitted or `null` `routing_key` values are parsed to their respective 
atoms. Those atoms are then stored in binding records. When a binding is 
retrieved or deleted (the case in #723), the conventionally encoded routing key 
that contained "null" for name was parsed to "null" (a string).
This  discrepancy led to false 404 responses from the API.

Note that this solution is merely a band aid over a fundamental 
difference in two APIs. Rejecting `null` or undefined values might be a better 
option but we cannot adopt it in 3.7.x. It remains to be discussed whether that
would improve user experience.

Another problematic scenario is routing keys with the value of "null"
(a string) used at binding time. This change would break deletion for
those. We'll assume that no developer would intentionally use such
routing key as the confusion and risk are more or less obvious.