### PR TITLE
Validate flags to disable features on runtime

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -128,10 +128,10 @@ disable_stats(ReqData) ->
                    <<"true">> -> true;
                    _ -> false
                end,
-    MgmtOnly orelse get_and_check_bool_env(rabbitmq_management, disable_management_stats, false)
-        orelse get_and_check_bool_env(rabbitmq_management_agent, disable_metrics_collector, false).
+    MgmtOnly orelse get_bool_env(rabbitmq_management, disable_management_stats, false)
+        orelse get_bool_env(rabbitmq_management_agent, disable_metrics_collector, false).
 
-get_and_check_bool_env(Application, Par, Default) ->
+get_bool_env(Application, Par, Default) ->
     case application:get_env(Application, Par, Default) of
         true -> true;
         false -> false;
@@ -196,7 +196,7 @@ is_authorized_global_parameters(ReqData, Context) ->
                   end).
 
 is_basic_auth_disabled() ->
-    get_and_check_bool_env(rabbitmq_management, disable_basic_auth, false).
+    get_bool_env(rabbitmq_management, disable_basic_auth, false).
 
 is_authorized(ReqData, Context, ErrorMsg, Fun) ->
     case cowboy_req:method(ReqData) of

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -3112,7 +3112,11 @@ disable_basic_auth_test(Config) ->
     http_put(Config, "/policies/%2F/HA",  Policy, ?NOT_AUTHORISED),
     http_delete(Config, "/queues/%2F/myqueue", ?NOT_AUTHORISED),
     http_get(Config, "/definitions", ?NOT_AUTHORISED),
-    http_post(Config, "/definitions", [], ?NOT_AUTHORISED).
+    http_post(Config, "/definitions", [], ?NOT_AUTHORISED),
+    rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
+                                 [rabbitmq_management, disable_basic_auth, 50]),
+    %% Defaults to 'false' when config is invalid
+    http_get(Config, "/overview", ?OK).
 
 %% -------------------------------------------------------------------
 %% Helpers.


### PR DESCRIPTION
Failure to do runtime validation caused an internal error (500 HTTP response code), as changes through `rabbitmqctl eval` are not validated by cuttlefish.

## Types of Changes
- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
