### PR TITLE
Ensure range type is set for new churn stats

### DIFF
--- a/priv/www/js/main.js
+++ b/priv/www/js/main.js
@@ -1697,6 +1697,15 @@ function get_chart_range_type(arg) {
     if (arg === 'queues') {
         return 'basic';
     }
+    if (arg === 'queue-churn') {
+        return 'basic';
+    }
+    if (arg === 'channel-churn') {
+        return 'basic';
+    }
+    if (arg === 'connection-churn') {
+        return 'basic';
+    }
 
     console.log('[WARNING]: range type not found for arg: ' + arg);
     return 'basic';


### PR DESCRIPTION
Fixes #720

This isn't a "fix" so much as it prevents a warning being logged to the console. `basic` is the correct range type for these new churn charts.