### PR TITLE
Ensure all data is read for multipart data

### DIFF
--- a/src/rabbit_mgmt_wm_definitions.erl
+++ b/src/rabbit_mgmt_wm_definitions.erl
@@ -264,20 +264,28 @@ format({vhost_limit_exceeded, ErrMsg}) ->
 format(E) ->
     rabbit_data_coercion:to_binary(rabbit_misc:format("~p", [E])).
 
-get_all_parts(ReqData) ->
-    get_all_parts(ReqData, []).
+get_all_parts(Req) ->
+    get_all_parts(Req, []).
 
-get_all_parts(ReqData0, Acc) ->
-    case cowboy_req:read_part(ReqData0) of
-        {done, ReqData} ->
-            {Acc, ReqData};
-        {ok, Headers, ReqData1} ->
+get_all_parts(Req0, Acc) ->
+    case cowboy_req:read_part(Req0) of
+        {done, Req1} ->
+            {Acc, Req1};
+        {ok, Headers, Req1} ->
             Name = case cow_multipart:form_data(Headers) of
-                {data, N} -> N;
-                {file, N, _, _} -> N
-            end,
-            {ok, Body, ReqData} = cowboy_req:read_part_body(ReqData1),
-            get_all_parts(ReqData, [{Name, Body}|Acc])
+                       {data, N} -> N;
+                       {file, N, _, _} -> N
+                   end,
+            {ok, Body, Req2} = stream_part_body(Req1, <<>>),
+            get_all_parts(Req2, [{Name, Body}|Acc])
+    end.
+
+stream_part_body(Req0, Acc) ->
+    case cowboy_req:read_part_body(Req0) of
+        {more, Data, Req1} ->
+            stream_part_body(Req1, <<Acc/binary, Data/binary>>);
+        {ok, Data, Req1} ->
+            {ok, <<Acc/binary, Data/binary>>, Req1}
     end.
 
 get_part(Name, Parts) ->


### PR DESCRIPTION
Fixes #739

*Requires this PR:* https://github.com/rabbitmq/rabbitmq-ct-helpers/pull/34

To test:

* Ensure the branch from rabbitmq/rabbitmq-ct-helpers#34 is checked out in `deps/rabbitmq_ct_helpers`
* Checkout commit fa5730f1a846e26d69c5573bd76cddf676cc60dd and run `make ct-rabbit_mgmt_http t=all_tests_without_prefix:long_definitions_multipart_test` - it should fail with `500`. If you look at the test node's log you will see the `badmatch ... more` error.
* Checkout the `rabbitmq-management-739` branch and re-run, the test will pass.