### PR TITLE
Display queue replicas and totals in metrics-less UI

### DIFF
--- a/priv/schema/rabbitmq_management.schema
+++ b/priv/schema/rabbitmq_management.schema
@@ -371,6 +371,9 @@ end}.
     {datatype, {enum, [true, false]}}
 ]}.
 
+{mapping, "management.enable_queue_totals", "rabbitmq_management.enable_queue_totals", [
+    {datatype, {enum, [true, false]}}]}.
+
 %% ===========================================================================
 %% Authorization
 

--- a/priv/www/js/global.js
+++ b/priv/www/js/global.js
@@ -151,7 +151,12 @@ var DISABLED_STATS_COLUMNS =
                    ['features',             'Features (with policy)', true],
                    ['features_no_policy',   'Features (no policy)',   false],
                    ['policy',               'Policy',                 false],
-                   ['state',                'State',                  true]]},
+                   ['state',                'State',                  true]],
+      'Messages': [['msgs-ready',      'Ready',          true],
+                   ['msgs-unacked',    'Unacknowledged', true],
+                   ['msgs-ram',        'In memory',      false],
+                   ['msgs-persistent', 'Persistent',     false],
+                   ['msgs-total',      'Total',          true]]},
      'connections':
      {'Overview': [['user',   'User name', true],
                    ['state',  'State',     true]]},
@@ -653,6 +658,7 @@ function setup_global_vars() {
     exchange_types = overview.exchange_types;
 
     disable_stats = overview.disable_stats;
+    enable_queue_totals = overview.enable_queue_totals;
     COLUMNS = disable_stats?DISABLED_STATS_COLUMNS:ALL_COLUMNS;
     
     setup_chart_ranges(overview.sample_retention_policies);

--- a/priv/www/js/tmpl/queue.ejs
+++ b/priv/www/js/tmpl/queue.ejs
@@ -1,12 +1,13 @@
 <h1>Queue <b><%= fmt_string(highlight_extra_whitespace(queue.name)) %></b><%= fmt_maybe_vhost(queue.vhost) %></h1>
 
-<% if(!disable_stats) { %>
 <div class="section">
   <h2>Overview</h2>
+<% if(!disable_stats) { %>
   <div class="hider updatable">
     <%= queue_lengths('lengths-q', queue) %>
 <% if (rates_mode != 'none') { %>
     <%= message_rates('msg-rates-q', queue.message_stats) %>
+<% } %>
 <% } %>
 
     <h3>Details</h3>
@@ -15,6 +16,7 @@
         <th>Features</th>
         <td><%= fmt_features(queue) %></td>
       </tr>
+<% if(!disable_stats) { %>
       <tr>
         <th>Policy</th>
         <td><%= link_policy(queue.vhost, queue.policy) %></td>
@@ -33,6 +35,7 @@
         <th>Effective policy definition</th>
         <td><%= fmt_table_short(queue.effective_policy_definition) %></td>
       </tr>
+<% } %>
 <% if (nodes_interesting) { %>
       <tr>
       <% if (is_quorum(queue)) { %>
@@ -40,7 +43,11 @@
       <% } else { %>
         <th>Node</th>
       <% } %>
+      <% if (queue.leader) { %>
+        <td><%= fmt_node(queue.leader) %></td>
+      <% } else { %>
         <td><%= fmt_node(queue.node) %></td>
+      <% } %>
       </tr>
   <% if (is_quorum(queue)) { %>
       <tr>
@@ -115,6 +122,7 @@
 <% } %>
     </table>
 
+<% if(!disable_stats) { %>
     <table class="facts facts-l">
       <tr>
         <th>State</th>
@@ -211,6 +219,7 @@
         <td class="r"><%= fmt_bytes(queue.memory) %></td>
       </tr>
     </table>
+    <% } %>
   </div>
 </div>
 
@@ -236,7 +245,6 @@
 </table>
 </div>
 </div>
-<% } %>
 
 <div class="section-hidden">
   <h2>Consumers</h2>

--- a/priv/www/js/tmpl/queues.ejs
+++ b/priv/www/js/tmpl/queues.ejs
@@ -9,11 +9,15 @@
  <thead>
   <tr>
     <%= group_heading('queues', 'Overview', [vhosts_interesting, nodes_interesting, true]) %>
-  <% if(!disable_stats) { %>
+<% if(disable_stats && enable_queue_totals) { %>
+    <%= group_heading('queues', 'Messages', []) %>
+<% } else { %>
+<% if(!disable_stats) { %>
     <%= group_heading('queues', 'Messages', []) %>
     <%= group_heading('queues', 'Message bytes', []) %>
 <% if (rates_mode != 'none') { %>
     <%= group_heading('queues', 'Message rates', []) %>
+<% } %>
 <% } %>
 <% } %>
     <th class="plus-minus"><span class="popup-options-link" title="Click to change columns" type="columns" for="queues">+/-</span></th>
@@ -47,7 +51,18 @@
 <% if (show_column('queues', 'state')) { %>
     <th><%= fmt_sort('State',        'state') %></th>
 <% } %>
-  <% if(!disable_stats) { %>
+<% if(disable_stats && enable_queue_totals) { %>
+<% if (show_column('queues', 'msgs-ready')) { %>
+    <th><%= fmt_sort('Ready',        'messages_ready') %></th>
+<% } %>
+<% if (show_column('queues', 'msgs-unacked')) { %>
+    <th><%= fmt_sort('Unacked',      'messages_unacknowledged') %></th>
+<% } %>
+<% if (show_column('queues', 'msgs-total')) { %>
+    <th><%= fmt_sort('Total',        'messages') %></th>
+<% } %>
+<% } %>
+<% if(!disable_stats) { %>
 <% if (show_column('queues', 'msgs-ready')) { %>
     <th><%= fmt_sort('Ready',        'messages_ready') %></th>
 <% } %>
@@ -148,22 +163,28 @@
 <% if (show_column('queues', 'state')) { %>
    <td class="c"><%= fmt_object_state(queue) %></td>
 <% } %>
-<% if(!disable_stats) { %>
+<% if(!disable_stats || (disable_stats && enable_queue_totals)) { %>
 <% if (show_column('queues', 'msgs-ready')) { %>
    <td class="r"><%= fmt_num_thousands(queue.messages_ready) %></td>
 <% } %>
 <% if (show_column('queues', 'msgs-unacked')) { %>
    <td class="r"><%= fmt_num_thousands(queue.messages_unacknowledged) %></td>
 <% } %>
+<% } %>
+<% if(!disable_stats) { %>
 <% if (show_column('queues', 'msgs-ram')) { %>
    <td class="r"><%= fmt_num_thousands(queue.messages_ram) %></td>
 <% } %>
 <% if (show_column('queues', 'msgs-persistent')) { %>
    <td class="r"><%= fmt_num_thousands(queue.messages_persistent) %></td>
 <% } %>
+<% } %>
+<% if(!disable_stats || (disable_stats && enable_queue_totals)) { %>
 <% if (show_column('queues', 'msgs-total')) { %>
    <td class="r"><%= fmt_num_thousands(queue.messages) %></td>
 <% } %>
+<% } %>
+<% if(!disable_stats) { %>
 <% if (show_column('queues', 'msg-bytes-ready')) { %>
    <td class="r"><%= fmt_bytes(queue.message_bytes_ready) %></td>
 <% } %>

--- a/priv/www/js/tmpl/queues.ejs
+++ b/priv/www/js/tmpl/queues.ejs
@@ -107,7 +107,11 @@
    <td><%= link_queue(queue.vhost, queue.name, queue.arguments) %></td>
 <% if (nodes_interesting) { %>
    <td>
-     <%= fmt_node(queue.node) %>
+     <% if (queue.node) { %>
+      <%= fmt_node(queue.node) %>
+     <% } else { %>
+      <%= fmt_node(queue.leader) %>
+     <% } %>
      <% if (queue.hasOwnProperty('members')) { %>
       <%= fmt_members(queue) %>
      <% } else { %>

--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -54,7 +54,7 @@
 -export([get_path_prefix/0]).
 -export([catch_no_such_user_or_vhost/2]).
 
--export([disable_stats/1]).
+-export([disable_stats/1, enable_queue_totals/1]).
 
 -import(rabbit_misc, [pget/2]).
 
@@ -132,6 +132,13 @@ disable_stats(ReqData) ->
                end,
     MgmtOnly orelse get_bool_env(rabbitmq_management, disable_management_stats, false)
         orelse get_bool_env(rabbitmq_management_agent, disable_metrics_collector, false).
+
+enable_queue_totals(ReqData) ->
+    EnableTotals = case qs_val(<<"enable_queue_totals">>, ReqData) of
+                       <<"true">> -> true;
+                       _ -> false
+                   end,
+    EnableTotals orelse get_bool_env(rabbitmq_management, enable_queue_totals, false).
 
 get_bool_env(Application, Par, Default) ->
     case application:get_env(Application, Par, Default) of

--- a/src/rabbit_mgmt_wm_overview.erl
+++ b/src/rabbit_mgmt_wm_overview.erl
@@ -56,7 +56,8 @@ to_json(ReqData, Context = #context{user = User = #user{tags = Tags}}) ->
                  {cluster_name,              rabbit_nodes:cluster_name()},
                  {erlang_version,            erlang_version()},
                  {erlang_full_version,       erlang_full_version()},
-                 {disable_stats,             rabbit_mgmt_util:disable_stats(ReqData)}],
+                 {disable_stats,             rabbit_mgmt_util:disable_stats(ReqData)},
+                 {enable_queue_totals,       rabbit_mgmt_util:enable_queue_totals(ReqData)}],
     try
         case rabbit_mgmt_util:disable_stats(ReqData) of
             false ->


### PR DESCRIPTION
Individual queue pages can list queue mirrors/members without peformance penalties as that data is part of the `amqqueue` record retrieved while listing queues.

Users want to see the total number of messages in the queues when using the Prometheus plugin, so this introduces an optional flag `enable_queue_totals` to list these in the UI (`queues` endpoint) with a lower performance penalty than listing all stats.

Depends on https://github.com/rabbitmq/rabbitmq-server/pull/2165

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories