### PR TITLE
pass authorisation context instead of channel source

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -831,7 +831,7 @@ direct_request(MethodName, Transformers, Extra, ErrorMsg, ReqData,
               Method = props_to_method(MethodName, Props, Transformers, Extra),
               Node = get_node(Props),
               case rabbit_misc:rpc_call(Node, rabbit_channel, handle_method,
-                                        [Method, none, ?MODULE, none,
+                                        [Method, none, #{}, none,
                                          VHost, User]) of
                   {badrpc, nodedown} ->
                       Msg = io_lib:format("Node ~p could not be contacted", [Node]),


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-server/pull/2169