### PR TITLE
Add support for queue_type argument

### DIFF
--- a/bin/rabbitmqadmin
+++ b/bin/rabbitmqadmin
@@ -109,6 +109,22 @@ URIS = {
     'vhost_limit': '/vhost-limits/{vhost}/{name}'
     }
 
+def queue_upload_fixup(upload):
+    # rabbitmq/rabbitmq-management#761
+    #
+    # In general, the fixup_upload argument can be used to fixup/change the
+    # upload dict after all argument parsing is complete.
+    #
+    # This simplifies setting the queue type for a new queue by allowing the
+    # user to use a queue_type=quorum argument rather than the somewhat confusing
+    # arguments='{"x-queue-type":"quorum"}' parameter
+    #
+    if 'queue_type' in upload:
+        queue_type = upload.get('queue_type')
+        arguments = upload.get('arguments', {})
+        arguments['x-queue-type'] = queue_type
+        upload['arguments'] = arguments
+
 DECLARABLE = {
     'exchange':   {'mandatory': ['name', 'type'],
                    'json':      ['arguments'],
@@ -117,7 +133,8 @@ DECLARABLE = {
     'queue':      {'mandatory': ['name'],
                    'json':      ['arguments'],
                    'optional':  {'auto_delete': 'false', 'durable': 'true',
-                                 'arguments': {}, 'node': None}},
+                                 'arguments': {}, 'node': None, 'queue_type': None},
+                   'fixup_upload': queue_upload_fixup},
     'binding':    {'mandatory': ['source', 'destination'],
                    'json':      ['arguments'],
                    'optional':  {'destination_type': 'queue',
@@ -806,6 +823,9 @@ class Management:
                 if k == 'destination_type':
                     uri_args['destination_char'] = v[0]
         uri = uri_template.format(**uri_args)
+        if 'fixup_upload' in obj:
+            fixup = obj['fixup_upload']
+            fixup(upload)
         return (uri, upload)
 
     def parse_json(self, text):

--- a/bin/rabbitmqadmin
+++ b/bin/rabbitmqadmin
@@ -778,6 +778,17 @@ class Management:
         (uri, upload) = self.parse_args(self.args[1:], obj)
         return (obj_type, uri, upload)
 
+    def assert_mandatory_keys(self, mandatory, upload):
+        for m in mandatory:
+            if type(m) is list:
+                a_set = set(m)
+                b_set = set(upload.keys())
+                assert_usage((a_set & b_set),
+                             'one of mandatory arguments "{0}" is required'.format(m))
+            else:
+                assert_usage(m in upload.keys(),
+                             'mandatory argument "{0}" is required'.format(m))
+
     def parse_args(self, args, obj):
         mandatory = obj['mandatory']
         optional = obj['optional']
@@ -806,15 +817,7 @@ class Management:
                 upload[name] = self.parse_json(value)
             else:
                 upload[name] = value
-        for m in mandatory:
-            if type(m) is list:
-                a_set = set(m)
-                b_set = set(upload.keys())
-                assert_usage((a_set & b_set),
-                             'one of mandatory arguments "{0}" is required'.format(m))
-            else:
-                assert_usage(m in upload.keys(),
-                             'mandatory argument "{0}" is required'.format(m))
+        self.assert_mandatory_keys(mandatory, upload)
         if 'vhost' not in mandatory:
             upload['vhost'] = self.options.vhost or self.options.declare_vhost
         uri_args = {}

--- a/bin/rabbitmqadmin
+++ b/bin/rabbitmqadmin
@@ -109,6 +109,7 @@ URIS = {
     'vhost_limit': '/vhost-limits/{vhost}/{name}'
     }
 
+
 def queue_upload_fixup(upload):
     # rabbitmq/rabbitmq-management#761
     #
@@ -124,6 +125,7 @@ def queue_upload_fixup(upload):
         arguments = upload.get('arguments', {})
         arguments['x-queue-type'] = queue_type
         upload['arguments'] = arguments
+
 
 DECLARABLE = {
     'exchange':   {'mandatory': ['name', 'type'],


### PR DESCRIPTION
This makes it easier to specify a quorum queue when creating a queue.

Otherwise, the awkward `arguments={x-queue-type:quorum}` argument must be used

Fixes #761