### PR TITLE
Add unsafe-inline to CSP policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ define PROJECT_ENV
 
 	    {cors_allow_origins, []},
 	    {cors_max_age, 1800},
-	    {content_security_policy, "script-src 'self' 'unsafe-eval'; object-src 'self'"}
+	    {content_security_policy, "script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'self'"}
 	  ]
 endef
 


### PR DESCRIPTION
Without this change, using the queue type dropdown will raise exceptions that can only be seen in the JS console.

Follow-up to #768

Thanks to @gerhard for finding this.