### PR TITLE
properties_key default value on binding deletable

### DIFF
--- a/bin/rabbitmqadmin
+++ b/bin/rabbitmqadmin
@@ -165,8 +165,8 @@ DECLARABLE = {
 DELETABLE = {
     'exchange':   {'mandatory': ['name']},
     'queue':      {'mandatory': ['name']},
-    'binding':    {'mandatory': ['source', 'destination_type', 'destination',
-                                 'properties_key']},
+    'binding':    {'mandatory': ['source', 'destination_type', 'destination'], 
+                    'optional': {'properties_key': '~'}},
     'vhost':      {'mandatory': ['name']},
     'user':       {'mandatory': ['name']},
     'permission': {'mandatory': ['vhost', 'user']},
@@ -207,7 +207,7 @@ for k in DECLARABLE:
 
 for k in DELETABLE:
     DELETABLE[k]['uri'] = URIS[k]
-    DELETABLE[k]['optional'] = {}
+    DELETABLE[k]['optional'] = DELETABLE[k].get('optional', {})
 DELETABLE['binding']['uri'] = URIS['binding_del']
 
 


### PR DESCRIPTION
Align create binding and delete banding convention. Use an empty
'~' properties_key by default as multiple users and I personally
find it inconvenient (and at first really time consuming)
to use the $HOME symbol for unbinding the default/simplest binding.

## Proposed Changes

Hi team,

This week I needed to troubleshoot RMQ relate code on an AWS ec2 instance and used `rabbitmqadmin` tool to do so. I encounter that when you create a simple queue/exchange binding:
`$ ./rabbitmqadmin declare binding source=myExchange destination='myQueue'`
The binding is created with `routing_key=''` and `properties_key='~'` by default. Then when I try to delete the newly created binding there is something that I find inconvenient and that's the fact that I have to explicitly set the `properties_key` value even if it is the one that is set by default - '\~'. I think that the two operations (declare & delete binding) should follow the same convention and the delete action should use '~' as a default value for `properties_key` as well. On the other hand, I and from what I can tell a few other people [issue 304](https://github.com/rabbitmq/rabbitmq-management/issues/304) find the deletion of the default/empty `properties_key` "hard to guess" so to speak as the most convenient and the things you try at first (delete without `properties_key` or `properties_key=''`) does not work so I needed to dive into the code to see what's going on.

Hopefully, you find this a beneficial change as I think this will save a lot of people's time when they want to delete a binding without properties_key.

Thanks,
Ivan
## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the mailing list. We're here to help! This is simply a reminder
of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories


