### PR TITLE
Add API endpoint /api/rebalance/queues

### DIFF
--- a/priv/www/api/index.html
+++ b/priv/www/api/index.html
@@ -1009,7 +1009,7 @@ or:
         <td>
           Rebalances all queues in all vhosts. This operation  is asynchronous therefore please check
           the RabbitMQ log file for messages regarding the success or failure of the operation.
-          <pre>curl -4u 'guest:guest' -XPOST localhost:15672/api/queues/rebalance</pre>
+          <pre>curl -4u 'guest:guest' -XPOST localhost:15672/api/rebalance/queues/</pre>
         </td>
       </tr>
     </table>

--- a/priv/www/api/index.html
+++ b/priv/www/api/index.html
@@ -1000,6 +1000,18 @@ or:
           status 200 with body: <pre>{"enable_uaa":"boolean", "uaa_client_id":"string", "uaa_location":"string"}</pre>
         </td>
       </tr>
+      <tr>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td>X</td>
+        <td class="path">/api/rebalance/queues</td>
+        <td>
+          Rebalances all queues in all vhosts. This operation  is asynchronous therefore please check
+          the RabbitMQ log file for messages regarding the success or failure of the operation.
+          <pre>curl -4u 'guest:guest' -XPOST localhost:15672/api/queues/rebalance</pre>
+        </td>
+      </tr>
     </table>
 
 

--- a/src/rabbit_mgmt_dispatcher.erl
+++ b/src/rabbit_mgmt_dispatcher.erl
@@ -173,6 +173,7 @@ dispatcher() ->
      {"/healthchecks/node/:node",                              rabbit_mgmt_wm_healthchecks, []},
      {"/reset",                                                rabbit_mgmt_wm_reset, []},
      {"/reset/:node",                                          rabbit_mgmt_wm_reset, []},
+     {"/rebalance/queues",                                     rabbit_mgmt_wm_rebalance, [{queues, all}]},
      {"/auth",                                                 rabbit_mgmt_wm_auth, []},
      {"/login",                                                rabbit_mgmt_wm_login, []}
     ].

--- a/src/rabbit_mgmt_dispatcher.erl
+++ b/src/rabbit_mgmt_dispatcher.erl
@@ -173,7 +173,7 @@ dispatcher() ->
      {"/healthchecks/node/:node",                              rabbit_mgmt_wm_healthchecks, []},
      {"/reset",                                                rabbit_mgmt_wm_reset, []},
      {"/reset/:node",                                          rabbit_mgmt_wm_reset, []},
-     {"/rebalance/queues",                                     rabbit_mgmt_wm_rebalance, [{queues, all}]},
+     {"/rebalance/queues",                                     rabbit_mgmt_wm_rebalance_queues, [{queues, all}]},
      {"/auth",                                                 rabbit_mgmt_wm_auth, []},
      {"/login",                                                rabbit_mgmt_wm_login, []}
     ].

--- a/src/rabbit_mgmt_wm_rebalance.erl
+++ b/src/rabbit_mgmt_wm_rebalance.erl
@@ -1,0 +1,64 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License at
+%% https://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%% License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% The Original Code is RabbitMQ Management Plugin.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2020 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(rabbit_mgmt_wm_rebalance).
+
+-export([init/2, service_available/2, resource_exists/2,
+         content_types_provided/2, content_types_accepted/2,
+         is_authorized/2, allowed_methods/2, accept_content/2]).
+-export([variances/2]).
+
+-include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+%%--------------------------------------------------------------------
+
+init(Req, [Mode]) ->
+    Headers = rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE),
+    {cowboy_rest, Headers, {Mode, #context{}}}.
+
+service_available(Req, {{queues, all}, _Context}=State) ->
+    {true, Req, State};
+service_available(Req, State) ->
+    {false, Req, State}.
+
+variances(Req, State) ->
+    {[<<"accept-encoding">>, <<"origin">>], Req, State}.
+
+content_types_provided(Req, State) ->
+    {[{{<<"text">>, <<"plain">>, '*'}, undefined}], Req, State}.
+
+content_types_accepted(Req, State) ->
+   {[{'*', accept_content}], Req, State}.
+
+allowed_methods(Req, State) ->
+    {[<<"POST">>], Req, State}.
+
+resource_exists(Req, State) ->
+    {true, Req, State}.
+
+accept_content(Req, {_Mode, #context{user = #user{username = _Username}}}=State) ->
+    try
+        spawn(fun() -> rabbit_amqqueue:rebalance(all, ".*", ".*") end),
+        {true, Req, State}
+    catch
+        {error, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), Req, State)
+    end.
+
+is_authorized(Req0, {Mode, Context0}) ->
+    {Res, Req1, Context1} = rabbit_mgmt_util:is_authorized_admin(Req0, Context0),
+    {Res, Req1, {Mode, Context1}}.

--- a/src/rabbit_mgmt_wm_rebalance_queues.erl
+++ b/src/rabbit_mgmt_wm_rebalance_queues.erl
@@ -53,7 +53,7 @@ resource_exists(Req, State) ->
 accept_content(Req, {_Mode, #context{user = #user{username = Username}}}=State) ->
     try
         spawn(fun() ->
-            rabbit_log:info("User '~s' has initiated a queue rebalance", [Username])
+            rabbit_log:info("User '~s' has initiated a queue rebalance", [Username]),
             rabbit_amqqueue:rebalance(all, ".*", ".*")
         end),
         {true, Req, State}

--- a/src/rabbit_mgmt_wm_rebalance_queues.erl
+++ b/src/rabbit_mgmt_wm_rebalance_queues.erl
@@ -52,8 +52,8 @@ resource_exists(Req, State) ->
 
 accept_content(Req, {_Mode, #context{user = #user{username = Username}}}=State) ->
     try
+        rabbit_log:info("User '~s' has initiated a queue rebalance", [Username]),
         spawn(fun() ->
-            rabbit_log:info("User '~s' has initiated a queue rebalance", [Username]),
             rabbit_amqqueue:rebalance(all, ".*", ".*")
         end),
         {true, Req, State}

--- a/src/rabbit_mgmt_wm_rebalance_queues.erl
+++ b/src/rabbit_mgmt_wm_rebalance_queues.erl
@@ -50,9 +50,12 @@ allowed_methods(Req, State) ->
 resource_exists(Req, State) ->
     {true, Req, State}.
 
-accept_content(Req, {_Mode, #context{user = #user{username = _Username}}}=State) ->
+accept_content(Req, {_Mode, #context{user = #user{username = Username}}}=State) ->
     try
-        spawn(fun() -> rabbit_amqqueue:rebalance(all, ".*", ".*") end),
+        spawn(fun() ->
+            rabbit_log:info("User '~s' has initiated a queue rebalance", [Username])
+            rabbit_amqqueue:rebalance(all, ".*", ".*")
+        end),
         {true, Req, State}
     catch
         {error, Reason} ->

--- a/src/rabbit_mgmt_wm_rebalance_queues.erl
+++ b/src/rabbit_mgmt_wm_rebalance_queues.erl
@@ -14,7 +14,7 @@
 %% Copyright (c) 2007-2020 Pivotal Software, Inc.  All rights reserved.
 %%
 
--module(rabbit_mgmt_wm_rebalance).
+-module(rabbit_mgmt_wm_rebalance_queues).
 
 -export([init/2, service_available/2, resource_exists/2,
          content_types_provided/2, content_types_accepted/2,


### PR DESCRIPTION
[171631361]

Add a new API endpoint to rebalance all queues in all vhosts. Only one rebalance operation can be running at a time.

Example API request:

```
curl -4vvvu guest:guest -XPOST localhost:15672/api/rebalance/queues
```

Requires rabbitmq/rabbitmq-server#2268

Fixes #782