### PR TITLE
Revert "Hide consumers on queue page when stats are disabled"

### DIFF
--- a/priv/www/js/tmpl/queue.ejs
+++ b/priv/www/js/tmpl/queue.ejs
@@ -246,14 +246,14 @@
 </div>
 </div>
 
+<% } %>
+
 <div class="section-hidden">
   <h2>Consumers</h2>
   <div class="hider updatable">
 <%= format('consumers', {'mode': 'queue', 'consumers': queue.consumer_details}) %>
   </div>
 </div>
-
-<% } %>
 
 <div class="section-hidden">
   <h2>Bindings</h2>


### PR DESCRIPTION
Reverts rabbitmq/rabbitmq-management#789 because it reintroduces #758.