### PR TITLE
Return TLS listener correctly

### DIFF
--- a/src/rabbit_mgmt_app.erl
+++ b/src/rabbit_mgmt_app.erl
@@ -125,8 +125,14 @@ get_legacy_listener() ->
     Listener.
 
 get_tls_listener() ->
-    {ok, Listener} = application:get_env(rabbitmq_management, ssl_config),
-    [{ssl, true}, {ssl_opts, Listener}].
+    {ok, Listener0} = application:get_env(rabbitmq_management, ssl_config),
+     case proplists:get_value(cowboy_opts, Listener0) of
+        undefined ->
+             [{ssl, true}, {ssl_opts, Listener0}];
+        CowboyOpts ->
+            Listener1 = lists:keydelete(cowboy_opts, 1, Listener0),
+            [{ssl, true}, {ssl_opts, Listener1}, {cowboy_opts, CowboyOpts}]
+     end.
 
 get_tcp_listener() ->
     application:get_env(rabbitmq_management, tcp_config, []).

--- a/test/listener_config_SUITE.erl
+++ b/test/listener_config_SUITE.erl
@@ -99,7 +99,37 @@ ssl_config_only(_Config) ->
     ?assertEqual(lists:usort(Expected), get_single_listener_config()).
 
 multiple_listeners(_Config) ->
-    ok.
+    application:set_env(rabbitmq_management, tcp_config, [
+        {port, 998},
+        {cowboy_opts, [
+            {idle_timeout, 10000}
+        ]}
+    ]),
+    application:set_env(rabbitmq_management, ssl_config, [
+        {port, 999},
+        {idle_timeout, 10000}
+    ]),
+    Expected = [
+        [
+            {cowboy_opts, [
+                {idle_timeout, 10000},
+                {sendfile, false}
+            ]},
+            {port,998}
+        ],
+
+        [
+            {cowboy_opts,[
+                {sendfile, false}
+            ]},
+            {ssl, true},
+            {ssl_opts, [
+                {port, 999},
+                {idle_timeout, 10000}
+            ]}
+        ]
+    ],
+    ?assertEqual(lists:usort(Expected), rabbit_mgmt_app:get_listeners_config()).
 
 
 get_single_listener_config() ->

--- a/test/listener_config_SUITE.erl
+++ b/test/listener_config_SUITE.erl
@@ -105,6 +105,3 @@ multiple_listeners(_Config) ->
 get_single_listener_config() ->
     [Config] = rabbit_mgmt_app:get_listeners_config(),
     lists:usort(Config).
-
-deep_sort(List) ->
-    lists:usort(lists:map(fun lists:usort/1, List)).

--- a/test/listener_config_SUITE.erl
+++ b/test/listener_config_SUITE.erl
@@ -26,13 +26,10 @@ all() ->
 groups() ->
     [{non_parallel_tests, [], [
         no_config_defaults,
-        legacy_config_only,
         tcp_config_only,
         ssl_config_only,
-        tcp_ssl_configs,
-        tcp_legacy_configs,
-        ssl_legacy_configs,
-        all_configs_ignore_legacy
+
+        multiple_listeners
         ]}].
 
 init_per_suite(Config) ->
@@ -54,114 +51,60 @@ end_per_testcase(_, Config) ->
     application:unset_env(rabbitmq_management, ssl_config),
     Config.
 
-no_config_defaults(_Config) ->
-    [[{cowboy_opts,[{sendfile,false}]}]] = rabbit_mgmt_app:get_listeners_config().
+%%
+%% Test Cases
+%%
 
-legacy_config_only(_Config) ->
-    single_listener_config(listener).
+no_config_defaults(_Config) ->
+    ?assertEqual([
+        [{cowboy_opts,[
+            {sendfile, false}
+        ]}]
+    ], rabbit_mgmt_app:get_listeners_config()).
+
 
 tcp_config_only(_Config) ->
-    single_listener_config(tcp_config).
+    application:set_env(rabbitmq_management, tcp_config, [
+        {port, 999},
+        {cowboy_opts, [
+            {idle_timeout, 10000}
+        ]}
+    ]),
+
+    Expected = [
+        {cowboy_opts,[
+            {idle_timeout, 10000},
+            {sendfile, false}
+        ]},
+        {port, 999}
+    ],
+    ?assertEqual(lists:usort(Expected), get_single_listener_config()).
 
 ssl_config_only(_Config) ->
-    single_listener_config(ssl_config, true).
+    application:set_env(rabbitmq_management, ssl_config, [
+        {port, 999},
+        {idle_timeout, 10000}
+    ]),
 
-tcp_ssl_configs(_Config) ->
-    multiple_listeners_configs(tcp_config, ssl_config).
+    Expected = [
+        {cowboy_opts,[
+            {sendfile,false}
+        ]},
+        {ssl, true},
+        {ssl_opts, [
+            {port, 999},
+            {idle_timeout, 10000}
+        ]}
+    ],
+    ?assertEqual(lists:usort(Expected), get_single_listener_config()).
 
-tcp_legacy_configs(_Config) ->
-    multiple_listeners_configs(tcp_config, listener, true).
-
-ssl_legacy_configs(_Config) ->
-    multiple_listeners_configs(listener, ssl_config).
-
-all_configs_ignore_legacy(_Config) ->
-    application:set_env(rabbitmq_management, listener, [{port, 1001}]),
-    multiple_listeners_configs(tcp_config, ssl_config).
-
-multiple_listeners_configs(TcpConfig, SSLConfig) ->
-    multiple_listeners_configs(TcpConfig, SSLConfig, false).
-
-
-multiple_listeners_configs(TcpConfig, SSLConfig, AddSSL) ->
-    SSLOpts = case AddSSL of
-        true  -> [{ssl,true}];
-        false -> []
-    end,
-    application:set_env(rabbitmq_management, TcpConfig, [{port, 999}]),
-    application:set_env(rabbitmq_management, SSLConfig, [{port, 1000}] ++ SSLOpts),
-
-    ExpectedPorts = [[{cowboy_opts, [{sendfile,false}]}, {port, 999}],
-                     [{cowboy_opts, [{sendfile,false}]}, {port, 1000}, {ssl, true}]],
-
-    ?assertEqual(sort_sort(ExpectedPorts), sort_sort(rabbit_mgmt_app:get_listeners_config())),
-
-    application:set_env(rabbitmq_management, TcpConfig,
-        [{port, 999}, {cowboy_opts, [{idle_timeout, 10000}]}]),
-    application:set_env(rabbitmq_management, SSLConfig,
-        [{port, 1000}, {cowboy_opts, [{idle_timeout, 10000}]}] ++ SSLOpts),
-
-    ExpectedIdleTimeouts =
-        sort_sort([[{cowboy_opts, lists:usort([{sendfile,false}, {idle_timeout, 10000}])},
-                     {port, 999}],
-                   [{cowboy_opts, lists:usort([{sendfile,false}, {idle_timeout, 10000}])},
-                     {port, 1000}, {ssl, true}]]),
-
-    ?assertEqual(ExpectedIdleTimeouts, sort_sort(rabbit_mgmt_app:get_listeners_config())),
-
-
-    application:set_env(rabbitmq_management, TcpConfig,
-        [{port, 999}, {cowboy_opts, [{sendfile, false}]}]),
-    application:set_env(rabbitmq_management, SSLConfig,
-        [{port, 1000}, {cowboy_opts, [{sendfile, false}]}] ++ SSLOpts),
-    ?assertEqual(ExpectedPorts, sort_sort(rabbit_mgmt_app:get_listeners_config())),
-
-
-    application:set_env(rabbitmq_management, TcpConfig,
-        [{port, 999}, {cowboy_opts, [{sendfile, true}]}]),
-    application:set_env(rabbitmq_management, SSLConfig,
-        [{port, 1000}, {cowboy_opts, [{sendfile, true}]}] ++ SSLOpts),
-
-    ExpectedSendfiles = sort_sort([[{cowboy_opts, [{sendfile, true}]}, {port, 999}],
-                                   [{cowboy_opts, [{sendfile, true}]}, {port, 1000}, {ssl, true}]]),
-    ?assertEqual(ExpectedSendfiles, sort_sort(rabbit_mgmt_app:get_listeners_config())).
-
-
-single_listener_config(ConfigKey) -> single_listener_config(ConfigKey, false).
-
-single_listener_config(ConfigKey, SSL) ->
-    SSLOpts = case SSL of
-        true  -> [{ssl,true}];
-        false -> []
-    end,
-    application:set_env(rabbitmq_management, ConfigKey, [{port, 999}]),
-    ExpectedPort = lists:usort([{cowboy_opts,[{sendfile,false}]}, {port, 999}]
-                               ++ SSLOpts),
-    ?assertEqual(ExpectedPort, get_single_listener_config()),
-
-    application:set_env(rabbitmq_management, ConfigKey,
-        [{port, 999}, {cowboy_opts, [{idle_timeout, 10000}]}]),
-
-    ExpectedIdleTimeout =
-        lists:usort([{cowboy_opts, lists:usort([{sendfile,false}, {idle_timeout, 10000}])},
-                                   {port, 999}] ++ SSLOpts),
-    ?assertEqual(ExpectedIdleTimeout, get_single_listener_config()),
-
-    application:set_env(rabbitmq_management, ConfigKey,
-        [{port, 999}, {cowboy_opts, [{sendfile, false}]}]),
-    ?assertEqual(ExpectedPort, get_single_listener_config()),
-
-    application:set_env(rabbitmq_management, ConfigKey,
-        [{port, 999}, {cowboy_opts, [{sendfile, true}]}]),
-
-    ExpectedSendfile = lists:usort([{cowboy_opts, [{sendfile, true}]},
-                                    {port, 999}] ++ SSLOpts),
-    ?assertEqual(ExpectedSendfile, get_single_listener_config()).
+multiple_listeners(_Config) ->
+    ok.
 
 
 get_single_listener_config() ->
     [Config] = rabbit_mgmt_app:get_listeners_config(),
     lists:usort(Config).
 
-sort_sort(List) ->
-    lists:usort(lists:map(fun(El) -> lists:usort(El) end, List)).
+deep_sort(List) ->
+    lists:usort(lists:map(fun lists:usort/1, List)).

--- a/test/rabbit_mgmt_http_SUITE.erl
+++ b/test/rabbit_mgmt_http_SUITE.erl
@@ -3093,13 +3093,6 @@ rates_test(Config) ->
     http_put(Config, "/queues/%2F/myqueue", none, {group, '2xx'}),
     {Conn, Ch} = open_connection_and_channel(Config),
     Pid = spawn_link(fun() -> publish(Ch) end),
-    Fun = fun() ->
-                  Overview = http_get(Config, "/overview"),
-                  MsgStats = maps:get(message_stats, Overview, #{}),
-                  HasPub = maps:get(rate, maps:get(publish_details, MsgStats, #{}), 0) > 0,
-                  QueueTotals = maps:get(queue_totals, Overview, #{}),
-                  HasPub andalso maps:get(messages_ready, QueueTotals, 0) > 0
-          end,
 
     Condition = fun() ->
         Overview = http_get(Config, "/overview"),


### PR DESCRIPTION
`ssl_opts` must be used so that TLS options are recognized.

Fixes #800

Also ensure TLS port is set.