### PR TITLE
Fix export using python 3

### DIFF
--- a/bin/rabbitmqadmin
+++ b/bin/rabbitmqadmin
@@ -690,17 +690,15 @@ class Management:
         if self.options.vhost:
             uri += "/%s" % quote_plus(self.options.vhost)
         definitions = self.get(uri)
-        f = open(path, 'wb')
-        f.write(definitions)
-        f.close()
+        with open(path, 'wb') as f:
+            f.write(definitions.encode())
         self.verbose("Exported definitions for %s to \"%s\""
                      % (self.options.hostname, path))
 
     def invoke_import(self):
         path = self.get_arg()
-        f = open(path, 'rb')
-        definitions = f.read()
-        f.close()
+        with open(path, 'rb') as f:
+            definitions = f.read()
         uri = "/definitions"
         if self.options.vhost:
             uri += "/%s" % quote_plus(self.options.vhost)
@@ -1054,13 +1052,12 @@ def write_payload_file(payload_file, json_list):
     result = json.loads(json_list)[0]
     payload = result['payload']
     payload_encoding = result['payload_encoding']
-    f = open(payload_file, 'wb')
-    if payload_encoding == 'base64':
-        data = base64.b64decode(payload)
-    else:
-        data = payload
-    f.write(data.encode("utf-8"))
-    f.close()
+    with open(payload_file, 'wb') as f:
+        if payload_encoding == 'base64':
+            data = base64.b64decode(payload)
+        else:
+            data = payload
+        f.write(data.encode("utf-8"))
 
 
 def print_bash_completion():


### PR DESCRIPTION
Without `.encode()` you get this error:

```
TypeError: a bytes-like object is required, not str
```

Also use `with` when appropriate