### PR TITLE
Fix net_timetime typo

### DIFF
--- a/priv/www/js/tmpl/partition.ejs
+++ b/priv/www/js/tmpl/partition.ejs
@@ -91,7 +91,7 @@
   </table>
 <p>
   This is a dangerous configuration; use of substantially
-  unequal <code>net_timetime</code> values can lead to partitions
+  unequal <code>net_ticktime</code> values can lead to partitions
   being falsely detected.
 </p>
 <p>


### PR DESCRIPTION
timetime->ticktime

## Proposed Changes

The warning text that pops up if a cluster is running with mixed net_ticktime has typo in it. It should say net_ticktime and not net_timetime.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the mailing list. We're here to help! This is simply a reminder
of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the
discussion by explaining why you chose the solution you did and what
alternatives you considered, etc.
