### PR TITLE
Load definitions from rabbitmq.load_definitions via a boot step

### DIFF
--- a/src/rabbit_mgmt_app.erl
+++ b/src/rabbit_mgmt_app.erl
@@ -31,6 +31,11 @@
 -define(DEFAULT_PORT, 15672).
 -define(DEFAULT_TLS_PORT, 15671).
 
+-rabbit_boot_step({rabbit_management_load_definitions,
+                   [{description, "Imports definition file at management.load_definitions"},
+                    {mfa,         {rabbit_mgmt_load_definitions, boot, []}},
+                    {enables,     empty_db_check}]}).
+
 start(_Type, _StartArgs) ->
     case application:get_env(rabbitmq_management_agent, disable_metrics_collector, false) of
         false ->

--- a/src/rabbit_mgmt_load_definitions.erl
+++ b/src/rabbit_mgmt_load_definitions.erl
@@ -18,7 +18,14 @@
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 
--export([maybe_load_definitions/0, maybe_load_definitions_from/2]).
+-export([boot/0, maybe_load_definitions/0, maybe_load_definitions_from/2]).
+
+%% This module exists for backwards compatibility only.
+%% Definition import functionality is now a core server feature.
+
+boot() ->
+    rabbit_log:debug("Will import definitions file from management.load_definitions"),
+    rabbit_definitions:maybe_load_definitions(rabbitmq_management, load_definitions).
 
 maybe_load_definitions() ->
     rabbit_definitions:maybe_load_definitions().


### PR DESCRIPTION
Previously we tried to rely on `rabbitmq_management` env
being loaded in the core. That is suboptimal and has unintentional side effects.

References rabbitmq/rabbitmq-management#2368, rabbitmq/rabbitmq-management#2373.
Closes rabbitmq/rabbitmq-management#818.
