### PR TITLE
Make it possible to configure db cache multiplier via rabbitmq.conf

### DIFF
--- a/priv/schema/rabbitmq_management.schema
+++ b/priv/schema/rabbitmq_management.schema
@@ -297,7 +297,18 @@ end}.
     {datatype, integer}, {validators, ["non_negative_integer"]}
 ]}.
 
+%%
+%% Inter-node query result caching
+%%
+
+{mapping, "management.db_cache_multiplier", "rabbitmq_management.management_db_cache_multiplier", [
+    {datatype, integer}, {validators, ["non_negative_integer"]}
+]}.
+
+
+%%
 %% CORS
+%%
 
 {mapping, "management.cors.allow_origins", "rabbitmq_management.cors_allow_origins", [
     {datatype, {enum, [none]}}

--- a/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -309,6 +309,19 @@
  },
 
  %%
+ %% Inter-node query result caching
+ %%
+ 
+ {db_cache_multiplier,
+  "management.db_cache_multiplier = 7",
+  [
+   {rabbitmq_management, [
+                          {management_db_cache_multiplier, 7}
+                         ]}
+  ], [rabbitmq_management]
+ },
+ 
+ %%
  %% CORS
  %%
 


### PR DESCRIPTION
Closes rabbitmq/rabbitmq-management#821.
