### PR TITLE
prevent sending authorization: null header

### DIFF
--- a/priv/www/js/main.js
+++ b/priv/www/js/main.js
@@ -1185,7 +1185,10 @@ function with_req(method, path, body, fun) {
     var json;
     var req = xmlHttpRequest();
     req.open(method, 'api' + path, true );
-    req.setRequestHeader('authorization', auth_header());
+    var header = auth_header();
+    if (header !== null) {
+        req.setRequestHeader('authorization', header);
+    }
     req.setRequestHeader('x-vhost', current_vhost);
     req.onreadystatechange = function () {
         if (req.readyState == 4) {


### PR DESCRIPTION
## Proposed Changes

Add additional check to prevent sending `"authorization": "null"` and prefer sending no header if no value known.

RabbitMQ version 3.8.5. Firefox version 78.0.1. Using basic authentication request for `/whoami` sends `"authorization": "null"` in case if no logins previously were made.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the mailing list. We're here to help! This is simply a reminder
of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

This is useful for me because I host rabbitmq management ui under a proxy which tries to read authorization header and fails assuming that `"null"` is invalid token.