### PR TITLE
fix zero time formatted as empty string

### DIFF
--- a/priv/www/js/formatters.js
+++ b/priv/www/js/formatters.js
@@ -72,7 +72,7 @@ function fmt_timestamp_mini(ts) {
 }
 
 function fmt_time(t, suffix) {
-    if (t == undefined || t == 0) return '';
+    if (typeof t === "undefined") return '';
     return t + suffix;
 }
 


### PR DESCRIPTION
## Proposed Changes

Previously the check was using non-strict equality, which meant that empty
string was displayed instead of 0. This can mislead users to think that
no value is set while actually, for example, the federation message expiry is
set to 0.

I checked other repos as well, and it always seems to be used the same way by the connection page and the shovel plugin. No other usages found. 

Here is a picture of the changes on the federation page: 

![image](https://user-images.githubusercontent.com/923194/91047109-daf0b380-e619-11ea-8177-240936d5a919.png)


## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the mailing list. We're here to help! This is simply a reminder
of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories


