### PR TITLE
Make healthchecks failures return an HTTP 500 instead of 200.

### DIFF
--- a/src/rabbit_mgmt_wm_healthchecks.erl
+++ b/src/rabbit_mgmt_wm_healthchecks.erl
@@ -50,9 +50,10 @@ to_json(ReqData, Context) ->
     end.
 
 failure(Message, ReqData, Context) ->
-    rabbit_mgmt_util:reply([{status, failed},
-                            {reason, Message}],
-                           ReqData, Context).
+    Response, ReqData1, Context1 = rabbit_mgmt_util:reply([{status, failed},
+                                                           {reason, Message}],
+                                                          ReqData, Context),
+    {stop, cowboy_req:reply(500, #{}, Response, ReqData1), Context1}.
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized(ReqData, Context).

--- a/src/rabbit_mgmt_wm_healthchecks.erl
+++ b/src/rabbit_mgmt_wm_healthchecks.erl
@@ -50,9 +50,9 @@ to_json(ReqData, Context) ->
     end.
 
 failure(Message, ReqData, Context) ->
-    Response, ReqData1, Context1 = rabbit_mgmt_util:reply([{status, failed},
-                                                           {reason, Message}],
-                                                          ReqData, Context),
+    {Response, ReqData1, Context1} = rabbit_mgmt_util:reply([{status, failed},
+                                                            {reason, Message}],
+                                                           ReqData, Context),
     {stop, cowboy_req:reply(500, #{}, Response, ReqData1), Context1}.
 
 is_authorized(ReqData, Context) ->


### PR DESCRIPTION
Fixes #840.

My Erlang is extremely rusty so this might be entirely the wrong way to do this, but I figured I would try.