### PR TITLE
Respond with a Bad Request when client provides double-encoded JSON

### DIFF
--- a/src/rabbit_mgmt_util.erl
+++ b/src/rabbit_mgmt_util.erl
@@ -814,7 +814,8 @@ decode(Body) ->
         case rabbit_json:decode(Body) of
             Val when is_map(Val)    -> {ok, Val};
             Val when is_list(Val)   -> {ok, maps:from_list(Val)};
-            Bin when is_binary(Bin) -> {error, not_json};
+            Bin when is_binary(Bin) -> {error, "invalid payload: the request body JSON-decoded to a string. "
+                                               "Is the input doubly-JSON-encoded?"};
             _                       -> {error, not_json}
         end
     catch error:_ -> {error, not_json}

--- a/test/rabbit_mgmt_only_http_SUITE.erl
+++ b/test/rabbit_mgmt_only_http_SUITE.erl
@@ -77,7 +77,9 @@ all_tests() -> [
     sorting_test,
     columns_test,
     if_empty_unused_test,
-    queues_enable_totals_test].
+    queues_enable_totals_test,
+    double_encoded_json_test
+    ].
 
 %% -------------------------------------------------------------------
 %% Testsuite setup/teardown.
@@ -911,6 +913,12 @@ queue_actions_test(Config) ->
     http_post(Config, "/queues/%2F/q/actions", [{action, cancel_sync}], {group, '2xx'}),
     http_post(Config, "/queues/%2F/q/actions", [{action, change_colour}], ?BAD_REQUEST),
     http_delete(Config, "/queues/%2F/q", {group, '2xx'}),
+    passed.
+
+double_encoded_json_test(Config) ->
+    Payload = rabbit_json:encode(rabbit_json:encode(#{<<"durable">> => true, <<"auto_delete">> => false})),
+    %% double-encoded JSON response is a 4xx, e.g. a Bad Request, and not a 500
+    http_put_raw(Config, "/queues/%2F/q", Payload, {group, '4xx'}),
     passed.
 
 exclusive_queue_test(Config) ->


### PR DESCRIPTION
instead of a 500.

@lukebakken I would understand if addressing this would be considered to be "too much" but looks like it's a pretty safe and minor change.

To run a focussed test:

``` shell
gmake ct-rabbit_mgmt_only_http t="all_tests_without_prefix:double_encoded_json_test"
```

Closes #839.