### PR TITLE
Include top-level port property for TLS listeners

### DIFF
--- a/test/listener_config_SUITE.erl
+++ b/test/listener_config_SUITE.erl
@@ -51,9 +51,11 @@ end_per_testcase(_, Config) ->
 
 no_config_defaults(_Config) ->
     ?assertEqual([
-        [{cowboy_opts,[
-            {sendfile, false}
-        ]}]
+        [
+            {cowboy_opts,[
+                {sendfile, false}
+            ]},
+            {port, 15672}]
     ], rabbit_mgmt_app:get_listeners_config()).
 
 
@@ -84,6 +86,7 @@ ssl_config_only(_Config) ->
         {cowboy_opts,[
             {sendfile,false}
         ]},
+        {port, 999},
         {ssl, true},
         {ssl_opts, [
             {port, 999},
@@ -116,6 +119,7 @@ multiple_listeners(_Config) ->
             {cowboy_opts,[
                 {sendfile, false}
             ]},
+            {port, 999},
             {ssl, true},
             {ssl_opts, [
                 {port, 999},


### PR DESCRIPTION
This value is used at listener registration and will show up in
`rabbitmq-diagnostics listeners' output.

Closes #857.
