### PR TITLE
Hide Purge option for stream queues

### DIFF
--- a/priv/www/js/tmpl/queue.ejs
+++ b/priv/www/js/tmpl/queue.ejs
@@ -377,6 +377,7 @@
   </div>
 </div>
 
+<% if (!is_stream(queue)) { %>
 <div class="section-hidden">
   <h2>Purge</h2>
   <div class="hider">
@@ -388,6 +389,7 @@
     </form>
   </div>
 </div>
+<% } %>
 
 <% if(queue.reductions || queue.garbage_collection) { %>
 <div class="section-hidden">


### PR DESCRIPTION
Purge is not supported by stream queues, so it can be permanently hidden.

## Types of Changes
- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

